### PR TITLE
Don't replace columns in ORDER BY, GROUP BY, and HAVING clauses

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 Pending release
 ---------------
 
-* Don't replace columns in ORDER BY clause.
+* Don't replace columns in ORDER BY, GROUP BY and HAVING clause.
 
 2.2.0 (2018-01-24)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 Pending release
 ---------------
 
-* New release notes go here
+* Don't replace columns in ORDER BY clause.
 
 2.2.0 (2018-01-24)
 ------------------

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -41,15 +41,15 @@ def test_select_order_by():
 
 def test_select_group_by():
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1') ==
-        'SELECT ... FROM a GROUP BY f1'
+        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1, f2') ==
+        'SELECT ... FROM a GROUP BY f1, f2'
     )
 
 
 def test_select_group_by_having():
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > 21') ==
-        'SELECT ... FROM a GROUP BY f1 HAVING f1 > #'
+        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > 21, f2 < 42') ==
+        'SELECT ... FROM a GROUP BY f1 HAVING f1 > #, f2 < #'
     )
 
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -35,7 +35,7 @@ def test_select_join():
 def test_select_order_by():
     assert (
         sql_fingerprint('SELECT f1, f2 FROM a ORDER BY f3, f4') ==
-        'SELECT ... FROM a ORDER BY ...'
+        'SELECT ... FROM a ORDER BY f3, f4'
     )
 
 


### PR DESCRIPTION
Fixes #143

I can write more unit tests if you'd like. I've tried to not change too much the existing function and put the specific logic of detecting `order by` in a dedicated generator. Let me know if the approach works for you.

And, again, if you think this is worth having a setting, I can put one (I guess the default value would be for keeping compatibility, but it means new users will not have the columns in their `order by`).