### PR TITLE
Tidy up for HIDE_COLUMNS

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ History
 Pending release
 ---------------
 
+.. Insert new release notes below this line
+
 * Don't replace selected columns according to settings.
 
 3.0.0 (2018-07-17)

--- a/README.rst
+++ b/README.rst
@@ -181,6 +181,20 @@ Django settings, for example:
 
 The possible keys to this dictionary are explained below.
 
+``HIDE_COLUMNS``
+----------------
+
+The ``HIDE_COLUMNS`` setting may be used to change the way **django-perf-rec**
+simplifies SQL in the recording files it makes. It takes a boolean:
+
+* ``True`` (default) causes column lists in queries to be collapsed, e.g.
+  ``SELECT a, b, c FROM t`` becomes ``SELECT ... FROM t``. This is useful
+  because selected columns often don't affect query time in typical
+  Django applications, it makes the records easier to read, and they then don't
+  need updating every time model fields are changed.
+* ``False`` stops the collapsing behaviour, causing all the columns to be
+  output in the files.
+
 ``MODE``
 --------
 

--- a/django_perf_rec/settings.py
+++ b/django_perf_rec/settings.py
@@ -7,23 +7,23 @@ from django.conf import settings
 class Settings(object):
 
     defaults = {
-        'MODE': 'once',
         'HIDE_COLUMNS': True,
+        'MODE': 'once',
     }
 
     def get_setting(self, key):
         try:
             return settings.PERF_REC[key]
-        except (AttributeError, IndexError):
+        except (AttributeError, KeyError):
             return self.defaults.get(key, None)
-
-    @property
-    def MODE(self):
-        return self.get_setting('MODE')
 
     @property
     def HIDE_COLUMNS(self):
         return self.get_setting('HIDE_COLUMNS')
+
+    @property
+    def MODE(self):
+        return self.get_setting('MODE')
 
 
 perf_rec_settings = Settings()

--- a/tests/test_api.perf.yml
+++ b/tests/test_api.perf.yml
@@ -26,6 +26,10 @@ RecordTests.test_single_cache_op:
 - cache|get: foo
 RecordTests.test_single_db_query:
 - db: 'SELECT #'
+RecordTests.test_single_db_query_model:
+- db: SELECT ... FROM "testapp_author"
+RecordTests.test_single_db_query_model_with_columns:
+- db: SELECT ... FROM "testapp_author"
 TestCaseMixinTests.test_record_performance:
 - cache|get: foo
 custom:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,6 +24,15 @@ class RecordTests(TestCase):
         with record():
             run_query('default', 'SELECT 1337')
 
+    def test_single_db_query_model(self):
+        with record():
+            list(Author.objects.all())
+
+    @override_settings(PERF_REC={'HIDE_COLUMNS': False})
+    def test_single_db_query_model_with_columns(self):
+        with record():
+            list(Author.objects.all())
+
     def test_multiple_db_queries(self):
         with record():
             run_query('default', 'SELECT 1337')

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,14 +1,7 @@
 # -*- coding:utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import pytest
-
 from django_perf_rec.sql import sql_fingerprint
-
-
-@pytest.fixture(autouse=True)
-def clear_lru_cache():
-    sql_fingerprint.cache_clear()
 
 
 def test_select():
@@ -19,10 +12,8 @@ def test_select():
 
 
 def test_select_show_columns(settings):
-    settings.PERF_REC = {'HIDE_COLUMNS': False}
-
     assert (
-        sql_fingerprint("SELECT `f1`, `f2` FROM `b`") ==
+        sql_fingerprint("SELECT `f1`, `f2` FROM `b`", hide_columns=False) ==
         "SELECT `f1`, `f2` FROM `b`"
     )
 
@@ -35,10 +26,8 @@ def test_select_where():
 
 
 def test_select_where_show_columns(settings):
-    settings.PERF_REC = {'HIDE_COLUMNS': False}
-
     assert (
-        sql_fingerprint("SELECT DISTINCT `table`.`field` FROM `table` WHERE `table`.`id` = 1") ==
+        sql_fingerprint("SELECT DISTINCT `table`.`field` FROM `table` WHERE `table`.`id` = 1", hide_columns=False) ==
         "SELECT DISTINCT `table`.`field` FROM `table` WHERE `table`.`id` = #"
     )
 
@@ -51,10 +40,8 @@ def test_select_comment():
 
 
 def test_select_comment_show_columns(settings):
-    settings.PERF_REC = {'HIDE_COLUMNS': False}
-
     assert (
-        sql_fingerprint("SELECT /* comment */ `f1`, `f2` FROM `b`") ==
+        sql_fingerprint("SELECT /* comment */ `f1`, `f2` FROM `b`", hide_columns=False) ==
         "SELECT /* comment */ `f1`, `f2` FROM `b`"
     )
 
@@ -67,10 +54,8 @@ def test_select_join():
 
 
 def test_select_join_show_columns(settings):
-    settings.PERF_REC = {'HIDE_COLUMNS': False}
-
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = 1') ==
+        sql_fingerprint('SELECT f1, f2 FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = 1', hide_columns=False) ==
         'SELECT f1, f2 FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = #'
     )
 
@@ -83,10 +68,8 @@ def test_select_order_by():
 
 
 def test_select_order_by_show_columns(settings):
-    settings.PERF_REC = {'HIDE_COLUMNS': False}
-
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a ORDER BY f3') ==
+        sql_fingerprint('SELECT f1, f2 FROM a ORDER BY f3', hide_columns=False) ==
         'SELECT f1, f2 FROM a ORDER BY f3'
     )
 
@@ -106,10 +89,8 @@ def test_select_group_by():
 
 
 def test_select_group_by_show_columns(settings):
-    settings.PERF_REC = {'HIDE_COLUMNS': False}
-
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1') ==
+        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1', hide_columns=False) ==
         'SELECT f1, f2 FROM a GROUP BY f1'
     )
 
@@ -129,10 +110,8 @@ def test_select_group_by_having():
 
 
 def test_select_group_by_having_show_columns(settings):
-    settings.PERF_REC = {'HIDE_COLUMNS': False}
-
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > 21') ==
+        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > 21', hide_columns=False) ==
         'SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > #'
     )
 
@@ -152,10 +131,8 @@ def test_insert():
 
 
 def test_insert_show_columns(settings):
-    settings.PERF_REC = {'HIDE_COLUMNS': False}
-
     assert (
-        sql_fingerprint("INSERT INTO `table` (`f1`, `f2`) VALUES ('v1', 2)") ==
+        sql_fingerprint("INSERT INTO `table` (`f1`, `f2`) VALUES ('v1', 2)", hide_columns=False) ==
         "INSERT INTO `table` (`f1`, `f2`) VALUES (#, #)"
     )
 


### PR DESCRIPTION
Refs #158. Follow up for #159 rather than going through review loop.

* Restore '.. Insert new release notes below this line' in changelog, leaving the hint for future changelog editors
* Document the setting in the README - important so that other users can take advantage!
* Stop reading settings inside `sql_fingerprint`, instead take a new argument. The pytest fixture that cleared the cache between runs showed the mistake in the API design. Users of the library would not know to clear that cache and instead could end up with weird errors, if they ended up changing `PERF_REC` settings during test runs - a not unreasonable thing to do if e.g. columns are only wanted to be shown on certain tests.
* Test at the API level (end user with setting) rather than just testing `sql_fingerprint` - a more accurate, integrated test.
* Fix catching `IndexError` instead of `KeyError` in settings - a pre-existing bug whenever there are two settings, discovered by the API layer test! (That's why it's important!)