### PR TITLE
Fix for HIDE_COLUMNS

### DIFF
--- a/django_perf_rec/db.py
+++ b/django_perf_rec/db.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.db import connections
 
 from .orm import patch_ORM_to_be_deterministic
+from .settings import perf_rec_settings
 from .sql import sql_fingerprint
 from .utils import sorted_names
 
@@ -58,9 +59,10 @@ class DBRecorder(object):
             @wraps(func)
             def inner(self, *args, **kwargs):
                 sql = func(*args, **kwargs)
+                hide_columns = perf_rec_settings.HIDE_COLUMNS
                 callback(DBOp(
                     alias=alias,
-                    sql=sql_fingerprint(sql),
+                    sql=sql_fingerprint(sql, hide_columns=hide_columns),
                 ))
                 return sql
 

--- a/tests/test_api.perf.yml
+++ b/tests/test_api.perf.yml
@@ -29,7 +29,7 @@ RecordTests.test_single_db_query:
 RecordTests.test_single_db_query_model:
 - db: SELECT ... FROM "testapp_author"
 RecordTests.test_single_db_query_model_with_columns:
-- db: SELECT ... FROM "testapp_author"
+- db: SELECT "testapp_author"."id", "testapp_author"."name", "testapp_author"."age" FROM "testapp_author"
 TestCaseMixinTests.test_record_performance:
 - cache|get: foo
 custom:


### PR DESCRIPTION
Refs #158.

Use the setting HIDE_COLUMNS and pass it as an argument to
``sql_fingerprint``.