### PR TITLE
Remove Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,9 @@ Pending release
 
 .. Insert new release notes below this line
 
+* Drop Python 2 support, only Python 3.4+ is supported now.
+* Dropped requirements for ``kwargs-only`` and ``six``.
+
 3.1.1 (2018-12-03)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,10 @@ Requirements
 
 Tested with all combinations of:
 
-* Python: 2.7, 3.6
+* Python: 3.6
 * Django: 1.8, 1.9, 1.10, 1.11, 2.0
+
+Python 3.4+ supported.
 
 N.B. When using Django 1.8 and SQLite the queries won't be rendered in SQL, but
 a format like 'QUERY = ... PARAMS = ...'. You can workaround this by

--- a/django_perf_rec/__init__.py
+++ b/django_perf_rec/__init__.py
@@ -1,21 +1,13 @@
-# -*- coding:utf-8 -*-
 """
 isort:skip_file
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import six
-
 try:
     import pytest
 except ImportError:
     pytest = None
 
 if pytest is not None:
-    if six.PY2:
-        pytest.register_assert_rewrite(b'django_perf_rec.api')
-    else:
-        pytest.register_assert_rewrite('django_perf_rec.api')
+    pytest.register_assert_rewrite('django_perf_rec.api')
 
 from .api import TestCaseMixin, get_record_name, get_perf_path, record  # noqa: F401
 

--- a/django_perf_rec/api.py
+++ b/django_perf_rec/api.py
@@ -1,13 +1,9 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 from threading import local
 
 from django.core.cache import DEFAULT_CACHE_ALIAS
 from django.db import DEFAULT_DB_ALIAS
 from django.utils.functional import SimpleLazyObject
-from kwargs_only import kwargs_only
 
 from . import pytest_plugin
 from .cache import AllCacheRecorder
@@ -19,8 +15,7 @@ from .yaml import KVFile
 record_current = local()
 
 
-@kwargs_only
-def record(record_name=None, path=None):
+def record(*, record_name=None, path=None):
     # Lazy since we may not need this to determine record_name or path,
     # depending on logic below
     test_details = SimpleLazyObject(current_test)
@@ -148,6 +143,5 @@ class TestCaseMixin(object):
     Adds record_performance() method to TestCase class it's mixed into
     for easy import-free use.
     """
-    @kwargs_only
-    def record_performance(self, record_name=None, path=None):
+    def record_performance(self, *, record_name=None, path=None):
         return record(record_name=record_name, path=path)

--- a/django_perf_rec/cache.py
+++ b/django_perf_rec/cache.py
@@ -1,13 +1,9 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import inspect
 import re
 from collections import Mapping, Sequence
 from functools import wraps
 from types import MethodType
 
-import six
 from django.conf import settings
 from django.core.cache import caches
 
@@ -19,7 +15,7 @@ class CacheOp(object):
     def __init__(self, alias, operation, key_or_keys):
         self.alias = alias
         self.operation = operation
-        if isinstance(key_or_keys, six.string_types):
+        if isinstance(key_or_keys, str):
             self.key_or_keys = self.clean_key(key_or_keys)
         elif isinstance(key_or_keys, (Mapping, Sequence)):
             self.key_or_keys = sorted(self.clean_key(k) for k in key_or_keys)
@@ -88,7 +84,7 @@ class CacheRecorder(object):
                 if not is_internal_call:
                     callback(CacheOp(
                         alias=alias,
-                        operation=six.text_type(func.__name__),
+                        operation=str(func.__name__),
                         key_or_keys=args[0],
                     ))
 

--- a/django_perf_rec/db.py
+++ b/django_perf_rec/db.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from functools import wraps
 from types import MethodType
 

--- a/django_perf_rec/orm.py
+++ b/django_perf_rec/orm.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import django
 import patchy
 from django.db.models.deletion import get_candidate_relations_to_delete

--- a/django_perf_rec/pytest_plugin.py
+++ b/django_perf_rec/pytest_plugin.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 in_pytest = False
 
 

--- a/django_perf_rec/settings.py
+++ b/django_perf_rec/settings.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.conf import settings
 
 

--- a/django_perf_rec/sql.py
+++ b/django_perf_rec/sql.py
@@ -1,7 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import six
 from django.utils.lru_cache import lru_cache
 from sqlparse import parse, tokens
 from sqlparse.sql import IdentifierList, Token
@@ -16,7 +12,7 @@ def sql_fingerprint(query, hide_columns=True):
     """
     parsed_query = parse(query)[0]
     sql_recursively_simplify(parsed_query, hide_columns=hide_columns)
-    return six.text_type(parsed_query)
+    return str(parsed_query)
 
 
 sql_deleteable_tokens = (

--- a/django_perf_rec/utils.py
+++ b/django_perf_rec/utils.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import difflib
 import inspect
 from collections import namedtuple

--- a/django_perf_rec/yaml.py
+++ b/django_perf_rec/yaml.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import errno
 import os
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,7 @@
 docutils
 flake8
 flake8-commas
-futures<3.2.0
 isort
-kwargs-only
-mock
 multilint
 patchy
 pytest
@@ -12,5 +9,4 @@ pytest-django
 pytz
 Pygments
 PyYAML
-six
 sqlparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,22 +6,14 @@
 #
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
-configparser==3.7.1       # via flake8
 docutils==0.14
-enum34==1.1.6             # via flake8
 flake8-commas==2.0.0
 flake8==3.6.0
-funcsigs==1.0.2           # via mock, pytest
-futures==3.1.1
 isort==4.3.4
-kwargs-only==1.0.0
 mccabe==0.6.1             # via flake8
-mock==2.0.0
 more-itertools==5.0.0     # via pytest
 multilint==2.4.0
 patchy==1.4.0
-pathlib2==2.3.3           # via pytest, pytest-django
-pbr==5.1.1                # via mock
 pluggy==0.8.1             # via pytest
 py==1.7.0                 # via pytest
 pycodestyle==2.4.0        # via flake8
@@ -31,6 +23,5 @@ pytest-django==3.4.5
 pytest==4.1.1
 pytz==2018.9
 pyyaml==3.13
-scandir==1.9.0            # via pathlib2
-six==1.12.0
+six==1.12.0               # via more-itertools, multilint, patchy, pytest
 sqlparse==0.2.4

--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import os
 import sys
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,11 +5,6 @@ universal = 1
 max-line-length = 120
 
 [isort]
-add_imports =
-    from __future__ import absolute_import
-    from __future__ import division
-    from __future__ import print_function
-    from __future__ import unicode_literals
 include_trailing_comma = True
 known_first_party = django_perf_rec
 known_third_party = django,yaml

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import codecs
 import os
 import re
 
@@ -9,17 +5,17 @@ from setuptools import find_packages, setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
 version = get_version(os.path.join('django_perf_rec', '__init__.py'))
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 setup(
@@ -35,13 +31,11 @@ setup(
     include_package_data=True,
     install_requires=[
         'Django',
-        'kwargs-only',
         'patchy',
         'PyYAML',
-        'six',
         'sqlparse>=0.2.0',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.4',
     license='MIT',
     zip_safe=False,
     keywords='Django',
@@ -60,8 +54,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/django18_sqlite3_backend/__init__.py
+++ b/tests/django18_sqlite3_backend/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals

--- a/tests/django18_sqlite3_backend/base.py
+++ b/tests/django18_sqlite3_backend/base.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.db.backends.sqlite3.base import DatabaseWrapper as OrigDatabaseWrapper
 
 from .operations import DatabaseOperations

--- a/tests/django18_sqlite3_backend/operations.py
+++ b/tests/django18_sqlite3_backend/operations.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.db.backends.sqlite3.operations import DatabaseOperations as OrigDatabaseOperations
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 
 import django

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,10 +1,6 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 
 import pytest
-import six
 from django.core.cache import caches
 from django.db.models import Q
 from django.db.models.functions import Upper
@@ -85,7 +81,7 @@ class RecordTests(TestCase):
             with record(record_name='custom'):
                 caches['default'].get('bar')
 
-        assert 'Performance record did not match' in six.text_type(excinfo.value)
+        assert 'Performance record did not match' in str(excinfo.value)
 
     def test_diff(self):
         with pretend_not_under_pytest():
@@ -96,7 +92,7 @@ class RecordTests(TestCase):
                 with record(record_name='test_diff'):
                     caches['default'].get('bar')
 
-            msg = six.text_type(excinfo.value)
+            msg = str(excinfo.value)
             assert '- cache|get: foo\n' in msg
             assert '+ cache|get: bar\n' in msg
 
@@ -172,7 +168,7 @@ class RecordTests(TestCase):
                 with record(path='perf_files/api/'):
                     caches['default'].get('foo')
 
-            assert 'Original performance record does not exist' in six.text_type(excinfo.value)
+            assert 'Original performance record does not exist' in str(excinfo.value)
 
             full_path = os.path.join(
                 FILE_DIR,
@@ -192,7 +188,7 @@ class RecordTests(TestCase):
                 with record(path='perf_files/api/'):
                     caches['default'].get('foo')
 
-            assert 'Original performance record did not exist' in six.text_type(excinfo.value)
+            assert 'Original performance record did not exist' in str(excinfo.value)
 
             full_path = os.path.join(
                 FILE_DIR,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
 from django.core.cache import caches
 from django.test import SimpleTestCase, TestCase

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import SimpleTestCase, TestCase
 
 from django_perf_rec.db import AllDBRecorder, DBOp, DBRecorder

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import SimpleTestCase
 
 from django_perf_rec.orm import patch_ORM_to_be_deterministic

--- a/tests/test_pytest_fixture_usage.py
+++ b/tests/test_pytest_fixture_usage.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
 
 from django_perf_rec import get_perf_path, get_record_name, record

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import SimpleTestCase
 
 from django_perf_rec import pytest_plugin

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django_perf_rec.sql import sql_fingerprint
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.test import SimpleTestCase
 
 from django_perf_rec.utils import current_test, sorted_names

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,11 +1,7 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import shutil
 from tempfile import mkdtemp
 
 import pytest
-import six
 import yaml
 from django.test import SimpleTestCase
 
@@ -63,7 +59,7 @@ class KVFileTests(SimpleTestCase):
 
         with pytest.raises(TypeError) as excinfo:
             KVFile(file_name)
-        assert 'not a dictionary' in six.text_type(excinfo.value)
+        assert 'not a dictionary' in str(excinfo.value)
 
     def test_get_after_set_same(self):
         kvf = KVFile(self.temp_dir + '/foo.yml')

--- a/tests/testapp/__init__.py
+++ b/tests/testapp/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from django.db import models
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import errno
 import os
 import shutil

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
-    py{27,36}-django{18,19,110,111},
-    py36-django{20,21},
-    py{27,36}-codestyle
+    py3-django{18,19,110,111,20,21},
+    py3-codestyle
 
 [testenv]
 setenv =
@@ -18,11 +17,6 @@ deps =
     -rrequirements.txt
 commands = ./runtests.py {posargs}
 
-[testenv:py27-codestyle]
-# setup.py check broken on travis python 2.7
-skip_install = true
-commands = multilint --skip setup.py
-
-[testenv:py36-codestyle]
+[testenv:py3-codestyle]
 skip_install = true
 commands = multilint


### PR DESCRIPTION
* Remove coding header and `__future__` imports
* Remove use of `six`
* Remove use of `kwargs-only`
* In `setup.py`, remove use of `codecs.open`, stop requiring `kwargs-only` and `six` in `install_requires`, update `python_requires` and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
* In `requirements.in`,  remove `futures` pin, `kwargs-only`, `mock`, and `six`, and recompile
* In `tox.ini`, stop testing on Python 2
* In `setup.cfg`, remove isort's `add_imports` for `__future__` imports