### PR TITLE
Fix a naming issue when two following test have the same name.

### DIFF
--- a/django_perf_rec/api.py
+++ b/django_perf_rec/api.py
@@ -39,6 +39,7 @@ def record(*, record_name=None, path=None):
         record_name = get_record_name(
             test_name=test_details.test_name,
             class_name=test_details.class_name,
+            file_name=file_name,
         )
 
     return PerformanceRecorder(file_name, record_name)
@@ -54,7 +55,7 @@ def get_perf_path(file_path):
     return perf_path
 
 
-def get_record_name(test_name, class_name=None):
+def get_record_name(test_name, class_name=None, file_name=''):
     if class_name:
         record_name = '{class_}.{test}'.format(
             class_=class_name,
@@ -63,12 +64,18 @@ def get_record_name(test_name, class_name=None):
     else:
         record_name = test_name
 
+    # Use both record_name and path to prevent generation of multiple calls in
+    # case of 2 following tests with same name and different modules, e.g:
+    #     foo.py::test_a
+    #     foo2.py::test_a
+    record_full_name = '{}::{}'.format(file_name, record_name)
+
     # Multiple calls inside the same test should end up suffixing with .2, .3 etc.
-    if getattr(record_current, 'record_name', None) == record_name:
+    if getattr(record_current, 'record_full_name', None) == record_full_name:
         record_current.counter += 1
         record_name = record_name + '.{}'.format(record_current.counter)
     else:
-        record_current.record_name = record_name
+        record_current.record_full_name = record_full_name
         record_current.counter = 1
 
     return record_name

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -240,6 +240,27 @@ class GetRecordNameTests(SimpleTestCase):
             'test_qux.2'
         )
 
+    def test_multiple_calls_from_different_files(self):
+        assert (
+            get_record_name(test_name='test_qux', file_name='foo.py') ==
+            'test_qux'
+        )
+
+        assert (
+            get_record_name(test_name='test_qux', file_name='foo2.py') ==
+            'test_qux'
+        )
+
+        assert (
+            get_record_name(test_name='test_qux', file_name='foo.py') ==
+            'test_qux'
+        )
+
+        assert (
+            get_record_name(test_name='test_qux', file_name='foo.py') ==
+            'test_qux.2'
+        )
+
 
 class TestCaseMixinTests(TestCaseMixin, TestCase):
 

--- a/tests/test_pytest_duplicate.perf.yml
+++ b/tests/test_pytest_duplicate.perf.yml
@@ -1,0 +1,2 @@
+test_duplicate_name:
+- db: 'SELECT #'

--- a/tests/test_pytest_duplicate.py
+++ b/tests/test_pytest_duplicate.py
@@ -1,0 +1,12 @@
+import pytest
+
+from django_perf_rec import record
+
+from .utils import run_query
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_duplicate_name():
+    with record():
+        run_query('default', 'SELECT 1337')

--- a/tests/test_pytest_duplicate_other.perf.yml
+++ b/tests/test_pytest_duplicate_other.perf.yml
@@ -1,0 +1,4 @@
+test_duplicate_name:
+- db: 'SELECT #'
+- db: 'SELECT #'
+- db: 'SELECT #'

--- a/tests/test_pytest_duplicate_other.py
+++ b/tests/test_pytest_duplicate_other.py
@@ -1,0 +1,16 @@
+import pytest
+from django.test.utils import override_settings
+
+from django_perf_rec import record
+
+from .utils import run_query
+
+pytestmark = [pytest.mark.django_db]
+
+
+@override_settings(PERF_REC={'MODE': 'none'})
+def test_duplicate_name():
+    with record():
+        run_query('default', 'SELECT 1337')
+        run_query('default', 'SELECT 4997')
+        run_query('default', 'SELECT 4998')

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,10 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     -rrequirements.txt
-commands = ./runtests.py {posargs}
+commands =
+    python -Wd runtests.py {posargs:tests}
+    # Test the issue of following duplicate test names in different modules.
+    python -Wd runtests.py tests/test_pytest_duplicate.py::test_duplicate_name tests/test_pytest_duplicate_other.py::test_duplicate_name
 
 [testenv:py3-codestyle]
 skip_install = true


### PR DESCRIPTION
I've added a rather strange test in `tox.ini` to validate the fix in real life. If someone have a better idea...