### PR TITLE
Tidy up test naming bug fix

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,9 @@ Pending release
 
 .. Insert new release notes below this line
 
+* Fix a bug in automatic test record naming when two different modules had a
+  test with the same class + name that ran one after another.
+
 4.0.0 (2019-02-01)
 ------------------
 

--- a/django_perf_rec/api.py
+++ b/django_perf_rec/api.py
@@ -64,18 +64,13 @@ def get_record_name(test_name, class_name=None, file_name=''):
     else:
         record_name = test_name
 
-    # Use both record_name and path to prevent generation of multiple calls in
-    # case of 2 following tests with same name and different modules, e.g:
-    #     foo.py::test_a
-    #     foo2.py::test_a
-    record_full_name = '{}::{}'.format(file_name, record_name)
-
     # Multiple calls inside the same test should end up suffixing with .2, .3 etc.
-    if getattr(record_current, 'record_full_name', None) == record_full_name:
+    record_spec = (file_name, record_name)
+    if getattr(record_current, 'record_spec', None) == record_spec:
         record_current.counter += 1
         record_name = record_name + '.{}'.format(record_current.counter)
     else:
-        record_current.record_full_name = record_full_name
+        record_current.record_spec = record_spec
         record_current.counter = 1
 
     return record_name

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,6 @@ deps =
     -rrequirements.txt
 commands =
     python -Wd runtests.py {posargs:tests}
-    # Test the issue of following duplicate test names in different modules.
-    python -Wd runtests.py tests/test_pytest_duplicate.py::test_duplicate_name tests/test_pytest_duplicate_other.py::test_duplicate_name
 
 [testenv:py3-codestyle]
 skip_install = true


### PR DESCRIPTION
* Add HISTORY note for users to see what changed
* Moved to storing a tuple on `record_current`, to avoid the unnecessary string formatting
* Removed the re-invoked test on tox - since the test records are committed to the repo, it doesn't seem necessary. The tests still fail if anything is broken.