### PR TITLE
Normalize SQL whitespace

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending release
 
 .. Insert new release notes below this line
 
+* Normalize SQL whitespace. This will change fingerprinted SQL in some cases.
+
 4.3.0 (2019-04-26)
 ------------------
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,6 +1,11 @@
 from django_perf_rec.sql import sql_fingerprint
 
 
+def test_empty():
+    assert sql_fingerprint('') == ''
+    assert sql_fingerprint("\n\n    \n") == ''
+
+
 def test_select():
     assert (
         sql_fingerprint("SELECT `f1`, `f2` FROM `b`") ==
@@ -12,6 +17,22 @@ def test_select_show_columns(settings):
     assert (
         sql_fingerprint("SELECT `f1`, `f2` FROM `b`", hide_columns=False) ==
         "SELECT `f1`, `f2` FROM `b`"
+    )
+
+
+def test_select_limit(settings):
+    assert (
+        sql_fingerprint("SELECT `f1`, `f2` FROM `b` LIMIT 12", hide_columns=False) ==
+        "SELECT `f1`, `f2` FROM `b` LIMIT #"
+    )
+
+
+def test_select_coalesce_show_columns(settings):
+    assert (
+        sql_fingerprint(
+            "SELECT `table`.`f1`, COALESCE(table.f2->>'a', table.f2->>'b', 'default') FROM `table`",
+            hide_columns=False) ==
+        "SELECT `table`.`f1`, COALESCE(table.f2->>#, table.f2->>#, #) FROM `table`"
     )
 
 
@@ -52,7 +73,9 @@ def test_select_join():
 
 def test_select_join_show_columns(settings):
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = 1', hide_columns=False) ==
+        sql_fingerprint(
+            'SELECT f1, f2 FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = 1',
+            hide_columns=False) ==
         'SELECT f1, f2 FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = #'
     )
 
@@ -61,6 +84,13 @@ def test_select_order_by():
     assert (
         sql_fingerprint('SELECT f1, f2 FROM a ORDER BY f3') ==
         'SELECT ... FROM a ORDER BY f3'
+    )
+
+
+def test_select_order_by_limit():
+    assert (
+        sql_fingerprint('SELECT f1, f2 FROM a ORDER BY f3 LIMIT 12') ==
+        'SELECT ... FROM a ORDER BY f3 LIMIT #'
     )
 
 
@@ -166,4 +196,58 @@ def test_release_savepoint():
     assert (
         sql_fingerprint("RELEASE SAVEPOINT `s140699855320896_x17`") ==
         "RELEASE SAVEPOINT `#`"
+    )
+
+
+def test_null_value():
+    assert (
+        sql_fingerprint(
+            "SELECT `f1`, `f2` FROM `b` WHERE `b`.`name` IS NULL",
+            hide_columns=False) ==
+        "SELECT `f1`, `f2` FROM `b` WHERE `b`.`name` IS #"
+    )
+
+
+def test_strip_duplicate_whitespaces():
+    assert (
+        sql_fingerprint(
+            "SELECT    `f1`,  `f2` FROM  `b` WHERE   `b`.`f1` IS  NULL LIMIT 12  ") ==
+        "SELECT ... FROM `b` WHERE `b`.`f1` IS # LIMIT #"
+    )
+
+
+def test_strip_duplicate_whitespaces_recursive():
+    assert (
+        sql_fingerprint(
+            "SELECT    `f1`,  `f2`, (   COALESCE(b.f3->>'en',   b.f3->>'fr', '')) "
+            "FROM  `b` WHERE   (`b`.`f1` IS   NULL OR (  EXISTS COUNT(1) )) LIMIT 12  ",
+            hide_columns=False) ==
+        "SELECT `f1`, `f2`, (COALESCE(b.f3->>#, b.f3->>#, #)) "
+        "FROM `b` WHERE (`b`.`f1` IS # OR (EXISTS COUNT(#))) LIMIT #"
+    )
+
+
+def test_strip_newlines():
+    assert (
+        sql_fingerprint("SELECT `f1`, `f2`\nFROM `b`\n LIMIT 12\n\n") ==
+        "SELECT ... FROM `b` LIMIT #"
+    )
+
+
+def test_strip_raw_query():
+    assert (
+        sql_fingerprint("""
+SELECT 'f1'
+    , 'f2'
+    , 'f3'
+FROM "table_a" WHERE "table_a"."f1" = 1 OR (
+"table_a"."type" = 'A' AND
+EXISTS (
+    SELECT "table_b"."id"
+    FROM "table_b"
+    WHERE "table_b"."id" = 1
+) = true)
+""") ==
+        'SELECT ... FROM "table_a" WHERE "table_a"."f1" = # OR ("table_a"."type" = #'
+        ' AND EXISTS (SELECT "table_b"."id" FROM "table_b" WHERE "table_b"."id" = # ) = true)'
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
     py3-django{111,20,21,22},
-    py3-codestyle,
-    coverage
+    py3-codestyle
 
 [testenv]
 setenv =
@@ -20,13 +19,3 @@ commands =
 [testenv:py3-codestyle]
 skip_install = true
 commands = multilint
-
-[testenv:coverage]
-basepython = python3.6
-deps = 
-    coverage
-    Django
-    -rrequirements.txt
-commands = 
-    python -Wd {envbindir}/coverage run --source=django_perf_rec runtests.py {posargs:tests}
-    coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py3-django{111,20,21,22},
-    py3-codestyle
+    py3-codestyle,
+    coverage
 
 [testenv]
 setenv =
@@ -19,3 +20,13 @@ commands =
 [testenv:py3-codestyle]
 skip_install = true
 commands = multilint
+
+[testenv:coverage]
+basepython = python3.6
+deps = 
+    coverage
+    Django
+    -rrequirements.txt
+commands = 
+    python -Wd {envbindir}/coverage run --source=django_perf_rec runtests.py {posargs:tests}
+    coverage report -m


### PR DESCRIPTION
Depending on django version or usage of raw queries you can have some issues:
  - parenthesis extraspaces are kept : `( COALESCE(...) )`, ` ( SELECT `
  - linebreak are not handled correctly : `AND\nEXISTS ` => `ANDEXISTS`

With sqlparse 0.2.4, we already have this issue in perfs-rec code
```
SELECT * FROM "table_a" WHERE "table_a"."f1" = 1 OR (
"table_a"."type" = 'A' AND
EXISTS (
    SELECT "table_b"."id"
    FROM "table_b"
    WHERE "table_b"."id" = 1
) = true)
```
have the following fingerprint
```
SELECT * FROM "table_a" WHERE "table_a"."f1" = # OR ("table_a"."type" = # ANDEXISTS ( SELECT "table_b"."id" FROM "table_b" WHERE "table_b"."id" = #) = true)
```

With sqlparse 0.3.0, parsing behaviour changes for whitespaces & linebreak cause even more issues and the fingerprint of the previous sample will be
```
SELECT * FROM "table_a" WHERE "table_a"."f1" = # OR ("table_a"."type" = # ANDEXISTS (    SELECT "table_b"."id"    FROM "table_b" WHERE "table_b"."id" = #) = true)
```

This PR may not fix all the issues but give a far better result
```
SELECT * FROM "table_a" WHERE "table_a"."f1" = # OR ("table_a"."type" = # AND EXISTS (SELECT "table_b"."id" FROM "table_b" WHERE "table_b"."id" = # ) = true)
```