### PR TITLE
Support Python 3.5 to 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
-sudo: false
 dist: xenial
 
 notifications:
   email: false
 
 language: python
-python: 3.6
 cache: pip
+
+matrix:
+  include:
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
 
 install:
   - pip install tox
 
-script: tox
+script:
+  - tox

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending release
 
 .. Insert new release notes below this line
 
+* Update Python support to 3.5-3.7, as 3.4 has reached its end of life.
+
 4.4.0 (2019-05-09)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -62,10 +62,10 @@ Requirements
 
 Tested with all combinations of:
 
-* Python: 3.6
+* Python: 3.5, 3.6, 3.7
 * Django: 1.11, 2.0, 2.1, 2.2
 
-Python 3.4+ supported.
+Python 3.5-3.7 supported.
 
 API
 ===

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ mccabe==0.6.1             # via flake8
 more-itertools==7.0.0     # via pytest
 multilint==2.4.0
 patchy==1.5.0
+pathlib2==2.3.3           # via pytest
 pluggy==0.11.0            # via pytest
 py==1.8.0                 # via pytest
 pycodestyle==2.5.0        # via flake8
@@ -24,5 +25,5 @@ pytest-django==3.4.8
 pytest==4.4.1
 pytz==2019.1
 pyyaml==5.1
-six==1.12.0               # via multilint, patchy, pytest
+six==1.12.0               # via multilint, patchy, pathlib2, pytest
 sqlparse==0.3.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'PyYAML',
         'sqlparse>=0.3.0',
     ],
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     license='MIT',
     zip_safe=False,
     keywords='Django',
@@ -54,8 +54,8 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )


### PR DESCRIPTION
* Update Travis config to use a matrix.
* Update README to say "Python 3.5-3.7 supported."
* Update `classifiers` and `python_requires` in `setup.py`
* Add note in `HISTORY.rst` "Update Python support to 3.5-3.7, as 3.4 has reached its end of life."