### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ django-perf-rec
 .. image:: https://img.shields.io/travis/adamchainz/django-perf-rec/master.svg
         :target: https://travis-ci.org/adamchainz/django-perf-rec
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
+
 "Keep detailed records of the performance of your Django code."
 
 **django-perf-rec** is like Django's ``assertNumQueries`` on steroids. It lets

--- a/django_perf_rec/__init__.py
+++ b/django_perf_rec/__init__.py
@@ -7,8 +7,8 @@ except ImportError:
     pytest = None
 
 if pytest is not None:
-    pytest.register_assert_rewrite('django_perf_rec.api')
+    pytest.register_assert_rewrite("django_perf_rec.api")
 
 from .api import TestCaseMixin, get_record_name, get_perf_path, record  # noqa: F401
 
-__version__ = '4.4.0'
+__version__ = "4.4.0"

--- a/django_perf_rec/api.py
+++ b/django_perf_rec/api.py
@@ -20,12 +20,12 @@ def record(*, record_name=None, path=None):
     # depending on logic below
     test_details = SimpleLazyObject(current_test)
 
-    if path is None or path.endswith('/'):
+    if path is None or path.endswith("/"):
         file_name = get_perf_path(test_details.file_path)
     else:
         file_name = path
 
-    if path is not None and path.endswith('/'):
+    if path is not None and path.endswith("/"):
         if not os.path.isabs(path):
             directory = os.path.join(os.path.dirname(test_details.file_path), path)
             if not os.path.exists(directory):
@@ -46,29 +46,26 @@ def record(*, record_name=None, path=None):
 
 
 def get_perf_path(file_path):
-    if file_path.endswith('.py'):
-        perf_path = file_path[:-len('.py')] + '.perf.yml'
-    elif file_path.endswith('.pyc'):
-        perf_path = file_path[:-len('.pyc')] + '.perf.yml'
+    if file_path.endswith(".py"):
+        perf_path = file_path[: -len(".py")] + ".perf.yml"
+    elif file_path.endswith(".pyc"):
+        perf_path = file_path[: -len(".pyc")] + ".perf.yml"
     else:
-        perf_path = file_path + '.perf.yml'
+        perf_path = file_path + ".perf.yml"
     return perf_path
 
 
-def get_record_name(test_name, class_name=None, file_name=''):
+def get_record_name(test_name, class_name=None, file_name=""):
     if class_name:
-        record_name = '{class_}.{test}'.format(
-            class_=class_name,
-            test=test_name,
-        )
+        record_name = "{class_}.{test}".format(class_=class_name, test=test_name)
     else:
         record_name = test_name
 
     # Multiple calls inside the same test should end up suffixing with .2, .3 etc.
     record_spec = (file_name, record_name)
-    if getattr(record_current, 'record_spec', None) == record_spec:
+    if getattr(record_current, "record_spec", None) == record_spec:
         record_current.counter += 1
-        record_name = record_name + '.{}'.format(record_current.counter)
+        record_name = record_name + ".{}".format(record_current.counter)
     else:
         record_current.record_spec = record_spec
         record_current.counter = 1
@@ -77,7 +74,6 @@ def get_record_name(test_name, class_name=None, file_name=''):
 
 
 class PerformanceRecorder(object):
-
     def __init__(self, file_name, record_name):
         self.file_name = file_name
         self.record_name = record_name
@@ -99,19 +95,19 @@ class PerformanceRecorder(object):
             self.save_or_assert()
 
     def on_db_op(self, db_op):
-        name_parts = ['db']
+        name_parts = ["db"]
         if db_op.alias != DEFAULT_DB_ALIAS:
             name_parts.append(db_op.alias)
-        name = '|'.join(name_parts)
+        name = "|".join(name_parts)
 
         self.record.append({name: db_op.sql})
 
     def on_cache_op(self, cache_op):
-        name_parts = ['cache']
+        name_parts = ["cache"]
         if cache_op.alias != DEFAULT_CACHE_ALIAS:
             name_parts.append(cache_op.alias)
         name_parts.append(cache_op.operation)
-        name = '|'.join(name_parts)
+        name = "|".join(name_parts)
 
         self.record.append({name: cache_op.key_or_keys})
 
@@ -121,23 +117,27 @@ class PerformanceRecorder(object):
     def save_or_assert(self):
         orig_record = self.records_file.get(self.record_name, None)
 
-        if perf_rec_settings.MODE == 'none':
-            assert orig_record is not None, "Original performance record does not exist for {}".format(self.record_name)
+        if perf_rec_settings.MODE == "none":
+            assert (
+                orig_record is not None
+            ), "Original performance record does not exist for {}".format(
+                self.record_name
+            )
 
         if orig_record is not None:
-            msg = "Performance record did not match for {}".format(
-                self.record_name,
-            )
+            msg = "Performance record did not match for {}".format(self.record_name)
             if not pytest_plugin.in_pytest:
-                msg += '\n{}'.format(
-                    record_diff(orig_record, self.record),
-                )
+                msg += "\n{}".format(record_diff(orig_record, self.record))
             assert self.record == orig_record, msg
 
         self.records_file.set_and_save(self.record_name, self.record)
 
-        if perf_rec_settings.MODE == 'all':
-            assert orig_record is not None, "Original performance record did not exist for {}".format(self.record_name)
+        if perf_rec_settings.MODE == "all":
+            assert (
+                orig_record is not None
+            ), "Original performance record did not exist for {}".format(
+                self.record_name
+            )
 
 
 class TestCaseMixin(object):
@@ -145,5 +145,6 @@ class TestCaseMixin(object):
     Adds record_performance() method to TestCase class it's mixed into
     for easy import-free use.
     """
+
     def record_performance(self, *, record_name=None, path=None):
         return record(record_name=record_name, path=path)

--- a/django_perf_rec/cache.py
+++ b/django_perf_rec/cache.py
@@ -11,7 +11,6 @@ from .utils import sorted_names
 
 
 class CacheOp(object):
-
     def __init__(self, alias, operation, key_or_keys):
         self.alias = alias
         self.operation = operation
@@ -25,31 +24,32 @@ class CacheOp(object):
     @classmethod
     def clean_key(cls, key):
         """
-        Replace things that look like variables with a '#' so tests aren't affected by random variables
+        Replace things that look like variables with a '#' so tests aren't
+        affected by random variables
         """
         for var_re in cls.VARIABLE_RES:
-            key = var_re.sub('#', key)
+            key = var_re.sub("#", key)
         return key
 
     VARIABLE_RES = (
         # Django session keys for 'cache' backend
-        re.compile(r'(?<=django\.contrib\.sessions\.cache)[0-9a-z]{32}\b'),
+        re.compile(r"(?<=django\.contrib\.sessions\.cache)[0-9a-z]{32}\b"),
         # Django session keys for 'cached_db' backend
-        re.compile(r'(?<=django\.contrib\.sessions\.cached_db)[0-9a-z]{32}\b'),
+        re.compile(r"(?<=django\.contrib\.sessions\.cached_db)[0-9a-z]{32}\b"),
         # Long random hashes
-        re.compile(r'\b[0-9a-f]{32}\b'),
+        re.compile(r"\b[0-9a-f]{32}\b"),
         # UUIDs
-        re.compile(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'),
+        re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"),
         # Integers
-        re.compile(r'\d+'),
+        re.compile(r"\d+"),
     )
 
     def __eq__(self, other):
         return (
-            isinstance(other, CacheOp) and
-            self.alias == other.alias and
-            self.operation == other.operation and
-            self.key_or_keys == other.key_or_keys
+            isinstance(other, CacheOp)
+            and self.alias == other.alias
+            and self.operation == other.operation
+            and self.key_or_keys == other.key_or_keys
         )
 
 
@@ -57,6 +57,7 @@ class CacheRecorder(object):
     """
     Monkey patches a cache class to call 'callback' on every operation it calls
     """
+
     def __init__(self, alias, callback):
         self.alias = alias
         self.callback = callback
@@ -76,29 +77,28 @@ class CacheRecorder(object):
                 frame = inspect.currentframe()
                 try:
                     frame = frame.f_back
-                    is_internal_call = frame.f_locals.get('self', None) is self
+                    is_internal_call = frame.f_locals.get("self", None) is self
                 finally:
                     # Always delete frame references to help garbage collector
                     del frame
 
                 if not is_internal_call:
-                    callback(CacheOp(
-                        alias=alias,
-                        operation=str(func.__name__),
-                        key_or_keys=args[0],
-                    ))
+                    callback(
+                        CacheOp(
+                            alias=alias,
+                            operation=str(func.__name__),
+                            key_or_keys=args[0],
+                        )
+                    )
 
                 return func(*args, **kwargs)
+
             return inner
 
         self.orig_methods = {name: getattr(cache, name) for name in self.cache_methods}
         for name in self.cache_methods:
             orig_method = self.orig_methods[name]
-            setattr(
-                cache,
-                name,
-                MethodType(call_callback(orig_method), cache),
-            )
+            setattr(cache, name, MethodType(call_callback(orig_method), cache))
 
     def __exit__(self, _, __, ___):
         cache = caches[self.alias]
@@ -107,15 +107,15 @@ class CacheRecorder(object):
         del self.orig_methods
 
     cache_methods = (
-        'add',
-        'decr',
-        'delete',
-        'delete_many',
-        'get',
-        'get_many',
-        'incr',
-        'set',
-        'set_many',
+        "add",
+        "decr",
+        "delete",
+        "delete_many",
+        "get",
+        "get_many",
+        "incr",
+        "set",
+        "set_many",
     )
 
 
@@ -123,6 +123,7 @@ class AllCacheRecorder(object):
     """
     Launches CacheRecorders on all the active caches
     """
+
     def __init__(self, callback):
         self.callback = callback
 

--- a/django_perf_rec/db.py
+++ b/django_perf_rec/db.py
@@ -11,7 +11,6 @@ from .utils import sorted_names
 
 
 class DBOp(object):
-
     def __init__(self, alias, sql):
         self.alias = alias
         self.sql = sql
@@ -21,9 +20,9 @@ class DBOp(object):
 
     def __eq__(self, other):
         return (
-            isinstance(other, DBOp) and
-            self.alias == other.alias and
-            self.sql == other.sql
+            isinstance(other, DBOp)
+            and self.alias == other.alias
+            and self.sql == other.sql
         )
 
 
@@ -32,6 +31,7 @@ class DBRecorder(object):
     Monkey-patch-wraps a database connection to call 'callback' on every
     query it runs.
     """
+
     def __init__(self, alias, callback):
         self.alias = alias
         self.callback = callback
@@ -57,18 +57,18 @@ class DBRecorder(object):
             def inner(self, *args, **kwargs):
                 sql = func(*args, **kwargs)
                 hide_columns = perf_rec_settings.HIDE_COLUMNS
-                callback(DBOp(
-                    alias=alias,
-                    sql=sql_fingerprint(sql, hide_columns=hide_columns),
-                ))
+                callback(
+                    DBOp(
+                        alias=alias, sql=sql_fingerprint(sql, hide_columns=hide_columns)
+                    )
+                )
                 return sql
 
             return inner
 
         self.orig_last_executed_query = connection.ops.last_executed_query
         connection.ops.last_executed_query = MethodType(
-            call_callback(connection.ops.last_executed_query),
-            connection.ops,
+            call_callback(connection.ops.last_executed_query), connection.ops
         )
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
@@ -81,6 +81,7 @@ class AllDBRecorder(object):
     """
     Launches DBRecorders on all database connections
     """
+
     def __init__(self, callback):
         self.callback = callback
 

--- a/django_perf_rec/orm.py
+++ b/django_perf_rec/orm.py
@@ -29,7 +29,9 @@ patch_ORM_to_be_deterministic.have_patched = False
 
 
 def patch_QuerySet():
-    patchy.patch(QuerySet.annotate, """\
+    patchy.patch(
+        QuerySet.annotate,
+        """\
         @@ -17,7 +17,7 @@
                  except (AttributeError, TypeError):
                      raise TypeError("Complex annotations require an alias")
@@ -39,12 +41,16 @@ def patch_QuerySet():
 
              clone = self._clone()
              names = self._fields
-    """)
+    """,
+    )
 
 
 if django.VERSION >= (2, 2):
+
     def patch_Query():
-        patchy.patch(Query.add_extra, """\
+        patchy.patch(
+            Query.add_extra,
+            """\
             @@ -13,7 +13,7 @@
                          param_iter = iter(select_params)
                      else:
@@ -54,10 +60,16 @@ if django.VERSION >= (2, 2):
                          entry = str(entry)
                          entry_params = []
                          pos = entry.find("%s")
-        """)
+        """,
+        )
+
+
 else:
+
     def patch_Query():
-        patchy.patch(Query.add_extra, """\
+        patchy.patch(
+            Query.add_extra,
+            """\
             @@ -13,7 +13,7 @@
                          param_iter = iter(select_params)
                      else:
@@ -67,7 +79,8 @@ else:
                          entry = force_text(entry)
                          entry_params = []
                          pos = entry.find("%s")
-        """)
+        """,
+        )
 
 
 def patch_Q():
@@ -76,4 +89,5 @@ def patch_Q():
     # fixed.
     def __init__(self, *args, **kwargs):
         super(Q, self).__init__(children=list(args) + sorted(kwargs.items()))
+
     Q.__init__ = __init__

--- a/django_perf_rec/settings.py
+++ b/django_perf_rec/settings.py
@@ -3,10 +3,7 @@ from django.conf import settings
 
 class Settings(object):
 
-    defaults = {
-        'HIDE_COLUMNS': True,
-        'MODE': 'once',
-    }
+    defaults = {"HIDE_COLUMNS": True, "MODE": "once"}
 
     def get_setting(self, key):
         try:
@@ -16,11 +13,11 @@ class Settings(object):
 
     @property
     def HIDE_COLUMNS(self):
-        return self.get_setting('HIDE_COLUMNS')
+        return self.get_setting("HIDE_COLUMNS")
 
     @property
     def MODE(self):
-        return self.get_setting('MODE')
+        return self.get_setting("MODE")
 
 
 perf_rec_settings = Settings()

--- a/django_perf_rec/sql.py
+++ b/django_perf_rec/sql.py
@@ -13,7 +13,7 @@ def sql_fingerprint(query, hide_columns=True):
     parsed_queries = parse(query)
 
     if not parsed_queries:
-        return ''
+        return ""
 
     parsed_query = sql_recursively_strip(parsed_queries[0])
     sql_recursively_simplify(parsed_query, hide_columns=hide_columns)
@@ -45,7 +45,7 @@ def sql_strip(node):
 
     for token in node.tokens:
         if token.is_whitespace:
-            token.value = '' if ws_count > 0 else ' '
+            token.value = "" if ws_count > 0 else " "
             ws_count += 1
         else:
             ws_count = 0
@@ -70,27 +70,37 @@ def sql_recursively_strip(node):
 
 def sql_recursively_simplify(node, hide_columns=True):
     # Erase which fields are being updated in an UPDATE
-    if node.tokens[0].value == 'UPDATE':
-        i_set = [i for (i, t) in enumerate(node.tokens) if t.value == 'SET'][0]
-        i_where = [i for (i, t) in enumerate(node.tokens)
-                   if t.is_group and t.tokens[0].value == 'WHERE'][0]
-        middle = [Token(tokens.Punctuation, ' ... ')]
-        node.tokens = node.tokens[:i_set + 1] + middle + node.tokens[i_where:]
+    if node.tokens[0].value == "UPDATE":
+        i_set = [i for (i, t) in enumerate(node.tokens) if t.value == "SET"][0]
+        i_where = [
+            i
+            for (i, t) in enumerate(node.tokens)
+            if t.is_group and t.tokens[0].value == "WHERE"
+        ][0]
+        middle = [Token(tokens.Punctuation, " ... ")]
+        node.tokens = node.tokens[: i_set + 1] + middle + node.tokens[i_where:]
 
     # Erase the names of savepoints since they are non-deteriministic
-    if hasattr(node, 'tokens'):
+    if hasattr(node, "tokens"):
         # SAVEPOINT x
-        if str(node.tokens[0]) == 'SAVEPOINT':
-            node.tokens[2].tokens[0].value = '`#`'
+        if str(node.tokens[0]) == "SAVEPOINT":
+            node.tokens[2].tokens[0].value = "`#`"
             return
         # RELEASE SAVEPOINT x
-        elif len(node.tokens) >= 3 and node.tokens[2].value == 'SAVEPOINT':
+        elif len(node.tokens) >= 3 and node.tokens[2].value == "SAVEPOINT":
             node.tokens[4].tokens[0].value = "`#`"
             return
         # ROLLBACK TO SAVEPOINT X
-        token_values = [getattr(t, 'value', '') for t in node.tokens]
-        if len(node.tokens) == 7 and token_values[:6] == ['ROLLBACK', ' ', 'TO', ' ', 'SAVEPOINT', ' ']:
-            node.tokens[6].tokens[0].value = '`#`'
+        token_values = [getattr(t, "value", "") for t in node.tokens]
+        if len(node.tokens) == 7 and token_values[:6] == [
+            "ROLLBACK",
+            " ",
+            "TO",
+            " ",
+            "SAVEPOINT",
+            " ",
+        ]:
+            node.tokens[6].tokens[0].value = "`#`"
             return
 
     # Erase volatile part of PG cursor name
@@ -100,21 +110,23 @@ def sql_recursively_simplify(node, hide_columns=True):
     prev_word_token = None
 
     for token in node.tokens:
-        ttype = getattr(token, 'ttype', None)
+        ttype = getattr(token, "ttype", None)
 
         # Detect IdentifierList tokens within an ORDER BY, GROUP BY or HAVING
         # clauses
-        inside_order_group_having = match_keyword(prev_word_token, ['ORDER BY', 'GROUP BY', 'HAVING'])
+        inside_order_group_having = match_keyword(
+            prev_word_token, ["ORDER BY", "GROUP BY", "HAVING"]
+        )
         replace_columns = not inside_order_group_having and hide_columns
 
         if isinstance(token, IdentifierList) and replace_columns:
-            token.tokens = [Token(tokens.Punctuation, '...')]
-        elif hasattr(token, 'tokens'):
+            token.tokens = [Token(tokens.Punctuation, "...")]
+        elif hasattr(token, "tokens"):
             sql_recursively_simplify(token, hide_columns=hide_columns)
         elif ttype in sql_deleteable_tokens:
-            token.value = '#'
-        elif getattr(token, 'value', None) == 'NULL':
-            token.value = '#'
+            token.value = "#"
+        elif getattr(token, "value", None) == "NULL":
+            token.value = "#"
 
         if not token.is_whitespace:
             prev_word_token = token

--- a/django_perf_rec/utils.py
+++ b/django_perf_rec/utils.py
@@ -8,20 +8,20 @@ except ImportError:
     FixtureRequest = None
 
 
-TestDetails = namedtuple('TestDetails', ['file_path', 'class_name', 'test_name'])
+TestDetails = namedtuple("TestDetails", ["file_path", "class_name", "test_name"])
 
 
 def current_test():
     """
-    Use a little harmless stack inspection to determine the test that is currently running.
+    Use a little harmless stack inspection to determine the test that is
+    currently running.
     """
     frame = inspect.currentframe()
     try:
         while True:
-            details = (
-                _get_details_from_test_function(frame) or
-                _get_details_from_pytest_request(frame)
-            )
+            details = _get_details_from_test_function(
+                frame
+            ) or _get_details_from_pytest_request(frame)
 
             if details:
                 return details
@@ -38,13 +38,13 @@ def current_test():
 
 
 def _get_details_from_test_function(frame):
-    if not frame.f_code.co_name.startswith('test_'):
+    if not frame.f_code.co_name.startswith("test_"):
         return
 
-    file_path = frame.f_globals['__file__']
+    file_path = frame.f_globals["__file__"]
 
     # May be a pytest function test so we can't assume 'self' exists
-    its_self = frame.f_locals.get('self', None)
+    its_self = frame.f_locals.get("self", None)
     if its_self is None:
         class_name = None
     else:
@@ -52,18 +52,14 @@ def _get_details_from_test_function(frame):
 
     test_name = frame.f_code.co_name
 
-    return TestDetails(
-        file_path=file_path,
-        class_name=class_name,
-        test_name=test_name,
-    )
+    return TestDetails(file_path=file_path, class_name=class_name, test_name=test_name)
 
 
 def _get_details_from_pytest_request(frame):
     if FixtureRequest is None:
         return
 
-    request = frame.f_locals.get('request', None)
+    request = frame.f_locals.get("request", None)
     if request is None:
         return
 
@@ -86,14 +82,14 @@ def sorted_names(names):
     names = list(names)
 
     have_default = False
-    if 'default' in names:
-        names.remove('default')
+    if "default" in names:
+        names.remove("default")
         have_default = True
 
     sorted_names = sorted(names)
 
     if have_default:
-        sorted_names = ['default'] + sorted_names
+        sorted_names = ["default"] + sorted_names
 
     return sorted_names
 
@@ -102,7 +98,9 @@ def record_diff(old, new):
     """
     Generate a human-readable diff of two performance records.
     """
-    return '\n'.join(difflib.ndiff(
-        ['%s: %s' % (k, v) for op in old for k, v in op.items()],
-        ['%s: %s' % (k, v) for op in new for k, v in op.items()],
-    ))
+    return "\n".join(
+        difflib.ndiff(
+            ["%s: %s" % (k, v) for op in old for k, v in op.items()],
+            ["%s: %s" % (k, v) for op in new for k, v in op.items()],
+        )
+    )

--- a/django_perf_rec/yaml.py
+++ b/django_perf_rec/yaml.py
@@ -6,7 +6,6 @@ from django.core.files import locks
 
 
 class KVFile(object):
-
     def __init__(self, file_name):
         self.file_name = file_name
         self.data = self.load(file_name)
@@ -25,12 +24,12 @@ class KVFile(object):
     @classmethod
     def load_file(cls, file_name):
         try:
-            with open(file_name, 'r') as fp:
+            with open(file_name, "r") as fp:
                 locks.lock(fp, locks.LOCK_EX)
                 content = fp.read()
         except IOError as exc:
             if exc.errno == errno.ENOENT:
-                content = '{}'
+                content = "{}"
             else:
                 raise
 
@@ -56,7 +55,7 @@ class KVFile(object):
             return
 
         fd = os.open(self.file_name, os.O_RDWR | os.O_CREAT)
-        with os.fdopen(fd, 'r+') as fp:
+        with os.fdopen(fd, "r+") as fp:
             locks.lock(fd, locks.LOCK_EX)
 
             data = yaml.safe_load(fp)
@@ -68,9 +67,5 @@ class KVFile(object):
 
             fp.seek(0)
             yaml.safe_dump(
-                data,
-                fp,
-                default_flow_style=False,
-                allow_unicode=True,
-                width=10000,
+                data, fp, default_flow_style=False, allow_unicode=True, width=10000
             )

--- a/requirements/py35-django111.txt
+++ b/requirements/py35-django111.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -35,9 +35,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py35-django20.txt
+++ b/requirements/py35-django20.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -35,9 +35,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py35-django21.txt
+++ b/requirements/py35-django21.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -35,9 +35,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py35-django22.txt
+++ b/requirements/py35-django22.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -35,9 +35,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36-django111.txt
+++ b/requirements/py36-django111.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -35,9 +35,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36-django20.txt
+++ b/requirements/py36-django20.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -35,9 +35,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36-django21.txt
+++ b/requirements/py36-django21.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -35,9 +35,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36-django22.txt
+++ b/requirements/py36-django22.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -35,9 +35,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py37-django111.txt
+++ b/requirements/py37-django111.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 django==1.11.21 \
     --hash=sha256:aae1b776d78cc3f492afda405b9b9d322b27761442997456c158687d7a0610a1 \
     --hash=sha256:ba723e524facffa2a9d8c2e9116db871e16b9207e648e1d3e4af8aae1167b029
@@ -35,9 +46,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -137,6 +148,10 @@ six==1.12.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/py37-django20.txt
+++ b/requirements/py37-django20.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 django==2.0.13 \
     --hash=sha256:665457d4146bbd34ae9d2970fa3b37082d7b225b0671bfd24c337458f229db78 \
     --hash=sha256:bde46d4dbc410678e89bc95ea5d312dd6eb4c37d0fa0e19c9415cad94addf22f
@@ -35,9 +46,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -137,6 +148,10 @@ six==1.12.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/py37-django21.txt
+++ b/requirements/py37-django21.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 django==2.1.9 \
     --hash=sha256:5052def4ff0a84bdf669827fdbd7b7cc1ac058f10232be6b21f37c6824f578da \
     --hash=sha256:bb72b5f8b53f8156280eaea520b548ac128a53f80cebc856c5e0fb555d44d529
@@ -35,9 +46,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -137,6 +148,10 @@ six==1.12.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/py37-django22.txt
+++ b/requirements/py37-django22.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 django==2.2.2 \
     --hash=sha256:753d30d3eb078064d2ddadfea65083c9848074a7f93d7b4dc7fa6b1380d278f5 \
     --hash=sha256:7cb67e8b934fab23b6daed7144da52e8a25a47eba7f360ca43d2b448506b01ad
@@ -35,9 +46,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -137,6 +148,10 @@ six==1.12.0 \
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,7 +1,8 @@
+black ; python_version == '3.7.*'
 django
 docutils
 flake8
-flake8-commas
+flake8-bugbear
 isort
 multilint
 patchy

--- a/runtests.py
+++ b/runtests.py
@@ -6,10 +6,10 @@ import pytest
 
 
 def main():
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
-    sys.path.insert(0, 'tests')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    sys.path.insert(0, "tests")
     return pytest.main()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,17 @@
 [flake8]
-max-line-length = 120
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E501,W503
 
 [isort]
 include_trailing_comma = True
+force_grid_wrap = 0
 known_first_party = django_perf_rec
 known_third_party = django,yaml
-line_length = 120
-multi_line_output = 5
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
 
 [metadata]
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -5,57 +5,49 @@ from setuptools import find_packages, setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with open(filename, "r") as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
-version = get_version(os.path.join('django_perf_rec', '__init__.py'))
+version = get_version(os.path.join("django_perf_rec", "__init__.py"))
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
-    history = history_file.read().replace('.. :changelog:', '')
+with open("HISTORY.rst", "r") as history_file:
+    history = history_file.read().replace(".. :changelog:", "")
 
 setup(
-    name='django-perf-rec',
+    name="django-perf-rec",
     version=version,
-    description="Keep detailed records of the performance of your Django "
-                "code.",
-    long_description=readme + '\n\n' + history,
-    author='Adam Johnson',
-    author_email='me@adamj.eu',
-    url='https://github.com/adamchainz/django-perf-rec',
-    packages=find_packages(exclude=['tests', 'tests.*']),
+    description="Keep detailed records of the performance of your Django " "code.",
+    long_description=readme + "\n\n" + history,
+    author="Adam Johnson",
+    author_email="me@adamj.eu",
+    url="https://github.com/adamchainz/django-perf-rec",
+    packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
-    install_requires=[
-        'Django>=1.11',
-        'patchy',
-        'PyYAML',
-        'sqlparse>=0.3.0',
-    ],
-    python_requires='>=3.5',
-    license='MIT',
+    install_requires=["Django>=1.11", "patchy", "PyYAML", "sqlparse>=0.3.0"],
+    python_requires=">=3.5",
+    license="MIT",
     zip_safe=False,
-    keywords='Django',
-    entry_points={
-        'pytest11': ['django_perf_rec = django_perf_rec.pytest_plugin'],
-    },
+    keywords="Django",
+    entry_points={"pytest11": ["django_perf_rec = django_perf_rec.pytest_plugin"]},
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 5 - Production/Stable",
+        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.0",
+        "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,73 +5,53 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
-SECRET_KEY = 'NOTASECRET'
+SECRET_KEY = "NOTASECRET"
 
 
-engine = 'django.db.backends.sqlite3'
+engine = "django.db.backends.sqlite3"
 
 DATABASES = {
-    'default': {
-        'ENGINE': engine,
-        'NAME': ':memory:',
-    },
-    'replica': {
-        'ENGINE': engine,
-        'NAME': ':memory:',
-        'TEST': {
-            'MIRROR': 'default',
-        },
-    },
-    'second': {
-        'ENGINE': engine,
-        'NAME': ':memory:',
-    },
+    "default": {"ENGINE": engine, "NAME": ":memory:"},
+    "replica": {"ENGINE": engine, "NAME": ":memory:", "TEST": {"MIRROR": "default"}},
+    "second": {"ENGINE": engine, "NAME": ":memory:"},
 }
 
 CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    },
-    'second': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    },
+    "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+    "second": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
 }
 
 ALLOWED_HOSTS = []
 
-INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'testapp',
-)
+INSTALLED_APPS = ("django.contrib.auth", "django.contrib.contenttypes", "testapp")
 
 MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 )
 
-ROOT_URLCONF = 'urls'
-LANGUAGE_CODE = 'en-us'
-TIME_ZONE = 'UTC'
+ROOT_URLCONF = "urls"
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
 USE_I18N = True
 USE_L10N = True
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-            ],
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ]
         },
-    },
+    }
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,264 +15,209 @@ FILE_DIR = os.path.dirname(__file__)
 
 
 class RecordTests(TestCase):
-
     def test_single_db_query(self):
         with record():
-            run_query('default', 'SELECT 1337')
+            run_query("default", "SELECT 1337")
 
     def test_single_db_query_model(self):
         with record():
             list(Author.objects.all())
 
-    @override_settings(PERF_REC={'HIDE_COLUMNS': False})
+    @override_settings(PERF_REC={"HIDE_COLUMNS": False})
     def test_single_db_query_model_with_columns(self):
         with record():
             list(Author.objects.all())
 
     def test_multiple_db_queries(self):
         with record():
-            run_query('default', 'SELECT 1337')
-            run_query('default', 'SELECT 4949')
+            run_query("default", "SELECT 1337")
+            run_query("default", "SELECT 4949")
 
     def test_non_deterministic_QuerySet_annotate(self):
         with record():
-            list(Author.objects.annotate(
-                x=Upper('name'),
-                y=Upper('name'),
-            ))
+            list(Author.objects.annotate(x=Upper("name"), y=Upper("name")))
 
     def test_non_deterministic_QuerySet_extra(self):
         with record():
-            list(Author.objects.extra(select={
-                'x': '1',
-                'y': '1',
-            }))
+            list(Author.objects.extra(select={"x": "1", "y": "1"}))
 
     def test_non_deterministic_Q_query(self):
         with record():
-            list(Author.objects.filter(Q(name='foo', age=1)))
+            list(Author.objects.filter(Q(name="foo", age=1)))
 
     def test_single_cache_op(self):
         with record():
-            caches['default'].get('foo')
+            caches["default"].get("foo")
 
     def test_multiple_cache_ops(self):
         with record():
-            caches['default'].set('foo', 'bar')
-            caches['second'].get_many(['foo', 'bar'])
-            caches['default'].delete('foo')
+            caches["default"].set("foo", "bar")
+            caches["second"].get_many(["foo", "bar"])
+            caches["default"].delete("foo")
 
     def test_multiple_calls_in_same_function_are_different_records(self):
         with record():
-            caches['default'].get('foo')
+            caches["default"].get("foo")
 
         with record():
-            caches['default'].get('bar')
+            caches["default"].get("bar")
 
     def test_custom_name(self):
-        with record(record_name='custom'):
-            caches['default'].get('foo')
+        with record(record_name="custom"):
+            caches["default"].get("foo")
 
     def test_custom_name_multiple_calls(self):
-        with record(record_name='custom'):
-            caches['default'].get('foo')
+        with record(record_name="custom"):
+            caches["default"].get("foo")
 
         with pytest.raises(AssertionError) as excinfo:
-            with record(record_name='custom'):
-                caches['default'].get('bar')
+            with record(record_name="custom"):
+                caches["default"].get("bar")
 
-        assert 'Performance record did not match' in str(excinfo.value)
+        assert "Performance record did not match" in str(excinfo.value)
 
     def test_diff(self):
         with pretend_not_under_pytest():
-            with record(record_name='test_diff'):
-                caches['default'].get('foo')
+            with record(record_name="test_diff"):
+                caches["default"].get("foo")
 
             with pytest.raises(AssertionError) as excinfo:
-                with record(record_name='test_diff'):
-                    caches['default'].get('bar')
+                with record(record_name="test_diff"):
+                    caches["default"].get("bar")
 
             msg = str(excinfo.value)
-            assert '- cache|get: foo\n' in msg
-            assert '+ cache|get: bar\n' in msg
+            assert "- cache|get: foo\n" in msg
+            assert "+ cache|get: bar\n" in msg
 
     def test_path_pointing_to_filename(self):
-        with temporary_path('custom.perf.yml'):
+        with temporary_path("custom.perf.yml"):
 
-            with record(path='custom.perf.yml'):
-                caches['default'].get('foo')
+            with record(path="custom.perf.yml"):
+                caches["default"].get("foo")
 
-            assert os.path.exists('custom.perf.yml')
+            assert os.path.exists("custom.perf.yml")
 
     def test_path_pointing_to_filename_record_twice(self):
-        with temporary_path('custom.perf.yml'):
+        with temporary_path("custom.perf.yml"):
 
-            with record(path='custom.perf.yml'):
-                caches['default'].get('foo')
+            with record(path="custom.perf.yml"):
+                caches["default"].get("foo")
 
-            with record(path='custom.perf.yml'):
-                caches['default'].get('foo')
+            with record(path="custom.perf.yml"):
+                caches["default"].get("foo")
 
     def test_path_pointing_to_dir(self):
-        temp_dir = os.path.join(FILE_DIR, 'perf_files/')
+        temp_dir = os.path.join(FILE_DIR, "perf_files/")
         with temporary_path(temp_dir):
 
-            with record(path='perf_files/'):
-                caches['default'].get('foo')
+            with record(path="perf_files/"):
+                caches["default"].get("foo")
 
-            full_path = os.path.join(
-                FILE_DIR,
-                'perf_files',
-                'test_api.perf.yml',
-            )
+            full_path = os.path.join(FILE_DIR, "perf_files", "test_api.perf.yml")
             assert os.path.exists(full_path)
 
     def test_custom_nested_path(self):
-        temp_dir = os.path.join(FILE_DIR, 'perf_files/')
+        temp_dir = os.path.join(FILE_DIR, "perf_files/")
         with temporary_path(temp_dir):
 
-            with record(path='perf_files/api/'):
-                caches['default'].get('foo')
+            with record(path="perf_files/api/"):
+                caches["default"].get("foo")
 
-            full_path = os.path.join(
-                FILE_DIR,
-                'perf_files',
-                'api',
-                'test_api.perf.yml',
-            )
+            full_path = os.path.join(FILE_DIR, "perf_files", "api", "test_api.perf.yml")
             assert os.path.exists(full_path)
 
-    @override_settings(PERF_REC={'MODE': 'once'})
+    @override_settings(PERF_REC={"MODE": "once"})
     def test_mode_once(self):
-        temp_dir = os.path.join(FILE_DIR, 'perf_files/')
+        temp_dir = os.path.join(FILE_DIR, "perf_files/")
         with temporary_path(temp_dir):
 
-            with record(path='perf_files/api/'):
-                caches['default'].get('foo')
+            with record(path="perf_files/api/"):
+                caches["default"].get("foo")
 
-            full_path = os.path.join(
-                FILE_DIR,
-                'perf_files',
-                'api',
-                'test_api.perf.yml',
-            )
+            full_path = os.path.join(FILE_DIR, "perf_files", "api", "test_api.perf.yml")
             assert os.path.exists(full_path)
 
-    @override_settings(PERF_REC={'MODE': 'none'})
+    @override_settings(PERF_REC={"MODE": "none"})
     def test_mode_none(self):
-        temp_dir = os.path.join(FILE_DIR, 'perf_files/')
+        temp_dir = os.path.join(FILE_DIR, "perf_files/")
         with temporary_path(temp_dir):
 
             with pytest.raises(AssertionError) as excinfo:
 
-                with record(path='perf_files/api/'):
-                    caches['default'].get('foo')
+                with record(path="perf_files/api/"):
+                    caches["default"].get("foo")
 
-            assert 'Original performance record does not exist' in str(excinfo.value)
+            assert "Original performance record does not exist" in str(excinfo.value)
 
-            full_path = os.path.join(
-                FILE_DIR,
-                'perf_files',
-                'api',
-                'test_api.perf.yml',
-            )
+            full_path = os.path.join(FILE_DIR, "perf_files", "api", "test_api.perf.yml")
             assert not os.path.exists(full_path)
 
-    @override_settings(PERF_REC={'MODE': 'all'})
+    @override_settings(PERF_REC={"MODE": "all"})
     def test_mode_all(self):
-        temp_dir = os.path.join(FILE_DIR, 'perf_files/')
+        temp_dir = os.path.join(FILE_DIR, "perf_files/")
         with temporary_path(temp_dir):
 
             with pytest.raises(AssertionError) as excinfo:
 
-                with record(path='perf_files/api/'):
-                    caches['default'].get('foo')
+                with record(path="perf_files/api/"):
+                    caches["default"].get("foo")
 
-            assert 'Original performance record did not exist' in str(excinfo.value)
+            assert "Original performance record did not exist" in str(excinfo.value)
 
-            full_path = os.path.join(
-                FILE_DIR,
-                'perf_files',
-                'api',
-                'test_api.perf.yml',
-            )
+            full_path = os.path.join(FILE_DIR, "perf_files", "api", "test_api.perf.yml")
             assert os.path.exists(full_path)
 
     def test_delete_on_cascade_called_twice(self):
-        arthur = Author.objects.create(name='Arthur', age=42)
+        arthur = Author.objects.create(name="Arthur", age=42)
         with record():
             arthur.delete()
 
 
 class GetPerfPathTests(SimpleTestCase):
-
     def test_py_file(self):
-        assert get_perf_path('foo.py') == 'foo.perf.yml'
+        assert get_perf_path("foo.py") == "foo.perf.yml"
 
     def test_pyc_file(self):
-        assert get_perf_path('foo.pyc') == 'foo.perf.yml'
+        assert get_perf_path("foo.pyc") == "foo.perf.yml"
 
     def test_unknown_file(self):
-        assert get_perf_path('foo.plob') == 'foo.plob.perf.yml'
+        assert get_perf_path("foo.plob") == "foo.plob.perf.yml"
 
 
 class GetRecordNameTests(SimpleTestCase):
-
     def test_class_and_test(self):
         assert (
-            get_record_name(class_name='FooTests', test_name='test_bar') ==
-            'FooTests.test_bar'
+            get_record_name(class_name="FooTests", test_name="test_bar")
+            == "FooTests.test_bar"
         )
 
     def test_just_test(self):
-        assert (
-            get_record_name(test_name='test_baz') ==
-            'test_baz'
-        )
+        assert get_record_name(test_name="test_baz") == "test_baz"
 
     def test_multiple_calls(self):
-        assert (
-            get_record_name(test_name='test_qux') ==
-            'test_qux'
-        )
-        assert (
-            get_record_name(test_name='test_qux') ==
-            'test_qux.2'
-        )
+        assert get_record_name(test_name="test_qux") == "test_qux"
+        assert get_record_name(test_name="test_qux") == "test_qux.2"
 
     def test_multiple_calls_from_different_files(self):
-        assert (
-            get_record_name(test_name='test_qux', file_name='foo.py') ==
-            'test_qux'
-        )
+        assert get_record_name(test_name="test_qux", file_name="foo.py") == "test_qux"
 
-        assert (
-            get_record_name(test_name='test_qux', file_name='foo2.py') ==
-            'test_qux'
-        )
+        assert get_record_name(test_name="test_qux", file_name="foo2.py") == "test_qux"
 
-        assert (
-            get_record_name(test_name='test_qux', file_name='foo.py') ==
-            'test_qux'
-        )
+        assert get_record_name(test_name="test_qux", file_name="foo.py") == "test_qux"
 
-        assert (
-            get_record_name(test_name='test_qux', file_name='foo.py') ==
-            'test_qux.2'
-        )
+        assert get_record_name(test_name="test_qux", file_name="foo.py") == "test_qux.2"
 
 
 class TestCaseMixinTests(TestCaseMixin, TestCase):
-
     def test_record_performance(self):
         with self.record_performance():
-            caches['default'].get('foo')
+            caches["default"].get("foo")
 
     def test_record_performance_record_name(self):
-        with self.record_performance(record_name='other'):
-            caches['default'].get('foo')
+        with self.record_performance(record_name="other"):
+            caches["default"].get("foo")
 
     def test_record_performance_file_name(self):
-        perf_name = __file__.replace('.py', '.file_name.perf.yml')
+        perf_name = __file__.replace(".py", ".file_name.perf.yml")
         with self.record_performance(path=perf_name):
-            caches['default'].get('foo')
+            caches["default"].get("foo")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -11,104 +11,82 @@ except ImportError:
 
 
 class CacheOpTests(SimpleTestCase):
-
     def test_clean_key_integer(self):
-        assert CacheOp.clean_key('foo1') == 'foo#'
+        assert CacheOp.clean_key("foo1") == "foo#"
 
     def test_clean_key_uuid(self):
-        assert CacheOp.clean_key('bdfc9986-d461-4a5e-bf98-8688993abcfb') == '#'
+        assert CacheOp.clean_key("bdfc9986-d461-4a5e-bf98-8688993abcfb") == "#"
 
     def test_clean_key_random_hash(self):
-        assert CacheOp.clean_key('abc123abc123abc123abc123abc12345') == '#'
+        assert CacheOp.clean_key("abc123abc123abc123abc123abc12345") == "#"
 
     def test_clean_key_session_key_cache_backend(self):
-        key = 'django.contrib.sessions.cacheabcdefghijklmnopqrstuvwxyz012345'
-        assert CacheOp.clean_key(key) == 'django.contrib.sessions.cache#'
+        key = "django.contrib.sessions.cacheabcdefghijklmnopqrstuvwxyz012345"
+        assert CacheOp.clean_key(key) == "django.contrib.sessions.cache#"
 
     def test_clean_key_session_key_cached_db_backend(self):
-        key = (
-            'django.contrib.sessions.cached_db' +
-            'abcdefghijklmnopqrstuvwxyz012345'
-        )
-        assert CacheOp.clean_key(key) == 'django.contrib.sessions.cached_db#'
+        key = "django.contrib.sessions.cached_db" + "abcdefghijklmnopqrstuvwxyz012345"
+        assert CacheOp.clean_key(key) == "django.contrib.sessions.cached_db#"
 
     def test_key(self):
-        op = CacheOp('default', 'foo', 'bar')
-        assert op.alias == 'default'
-        assert op.operation == 'foo'
-        assert op.key_or_keys == 'bar'
+        op = CacheOp("default", "foo", "bar")
+        assert op.alias == "default"
+        assert op.operation == "foo"
+        assert op.key_or_keys == "bar"
 
     def test_keys(self):
-        op = CacheOp('default', 'foo', ['bar', 'baz'])
-        assert op.alias == 'default'
-        assert op.operation == 'foo'
-        assert op.key_or_keys == ['bar', 'baz']
+        op = CacheOp("default", "foo", ["bar", "baz"])
+        assert op.alias == "default"
+        assert op.operation == "foo"
+        assert op.key_or_keys == ["bar", "baz"]
 
     def test_invalid(self):
         with pytest.raises(ValueError):
-            CacheOp('x', 'foo', object())
+            CacheOp("x", "foo", object())
 
     def test_equal(self):
-        assert (
-            CacheOp('x', 'foo', 'bar') ==
-            CacheOp('x', 'foo', 'bar')
-        )
+        assert CacheOp("x", "foo", "bar") == CacheOp("x", "foo", "bar")
 
     def test_not_equal_alias(self):
-        assert (
-            CacheOp('x', 'foo', 'bar') !=
-            CacheOp('y', 'foo', 'bar')
-        )
+        assert CacheOp("x", "foo", "bar") != CacheOp("y", "foo", "bar")
 
     def test_not_equal_operation(self):
-        assert (
-            CacheOp('x', 'foo', 'bar') !=
-            CacheOp('x', 'bar', 'bar')
-        )
+        assert CacheOp("x", "foo", "bar") != CacheOp("x", "bar", "bar")
 
     def test_not_equal_keys(self):
-        assert (
-            CacheOp('x', 'foo', ['bar']) !=
-            CacheOp('x', 'foo', ['baz'])
-        )
+        assert CacheOp("x", "foo", ["bar"]) != CacheOp("x", "foo", ["baz"])
 
 
 class CacheRecorderTests(TestCase):
-
     def test_default(self):
         callback = mock.Mock()
-        with CacheRecorder('default', callback):
-            caches['default'].get('foo')
-        callback.assert_called_once_with(
-            CacheOp('default', 'get', 'foo'),
-        )
+        with CacheRecorder("default", callback):
+            caches["default"].get("foo")
+        callback.assert_called_once_with(CacheOp("default", "get", "foo"))
 
     def test_secondary(self):
         callback = mock.Mock()
-        with CacheRecorder('second', callback):
-            caches['second'].get('foo')
-        callback.assert_called_once_with(
-            CacheOp('second', 'get', 'foo'),
-        )
+        with CacheRecorder("second", callback):
+            caches["second"].get("foo")
+        callback.assert_called_once_with(CacheOp("second", "get", "foo"))
 
     def test_secondary_default_not_recorded(self):
         callback = mock.Mock()
-        with CacheRecorder('second', callback):
-            caches['default'].get('foo')
+        with CacheRecorder("second", callback):
+            caches["default"].get("foo")
         assert len(callback.mock_calls) == 0
 
 
 class AllCacheRecorderTests(TestCase):
-
     def test_records_all(self):
         callback = mock.Mock()
         with AllCacheRecorder(callback):
-            caches['default'].get('foo')
-            caches['second'].set('bar', 'baz')
-            caches['default'].delete_many(['foo'])
+            caches["default"].get("foo")
+            caches["second"].set("bar", "baz")
+            caches["default"].delete_many(["foo"])
 
         assert callback.mock_calls == [
-            mock.call(CacheOp('default', 'get', 'foo')),
-            mock.call(CacheOp('second', 'set', 'bar')),
-            mock.call(CacheOp('default', 'delete_many', ['foo'])),
+            mock.call(CacheOp("default", "get", "foo")),
+            mock.call(CacheOp("second", "set", "bar")),
+            mock.call(CacheOp("default", "delete_many", ["foo"])),
         ]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -11,71 +11,61 @@ except ImportError:
 
 
 class DBOpTests(SimpleTestCase):
-
     def test_create(self):
-        op = DBOp('myalias', 'SELECT 1')
-        assert op.alias == 'myalias'
-        assert op.sql == 'SELECT 1'
+        op = DBOp("myalias", "SELECT 1")
+        assert op.alias == "myalias"
+        assert op.sql == "SELECT 1"
 
     def test_equal(self):
-        assert (
-            DBOp('foo', 'bar') ==
-            DBOp('foo', 'bar')
-        )
+        assert DBOp("foo", "bar") == DBOp("foo", "bar")
 
     def test_not_equal_alias(self):
-        assert (
-            DBOp('foo', 'bar') !=
-            DBOp('baz', 'bar')
-        )
+        assert DBOp("foo", "bar") != DBOp("baz", "bar")
 
     def test_not_equal_sql(self):
-        assert (
-            DBOp('foo', 'bar') !=
-            DBOp('foo', 'baz')
-        )
+        assert DBOp("foo", "bar") != DBOp("foo", "baz")
 
 
 class DBRecorderTests(TestCase):
-    databases = ('default', 'second', 'replica')
+    databases = ("default", "second", "replica")
 
     def test_default(self):
         callback = mock.Mock()
-        with DBRecorder('default', callback):
-            run_query('default', 'SELECT 1')
-        callback.assert_called_once_with(DBOp('default', 'SELECT #'))
+        with DBRecorder("default", callback):
+            run_query("default", "SELECT 1")
+        callback.assert_called_once_with(DBOp("default", "SELECT #"))
 
     def test_secondary(self):
         callback = mock.Mock()
-        with DBRecorder('second', callback):
-            run_query('second', 'SELECT 1')
-        callback.assert_called_once_with(DBOp('second', 'SELECT #'))
+        with DBRecorder("second", callback):
+            run_query("second", "SELECT 1")
+        callback.assert_called_once_with(DBOp("second", "SELECT #"))
 
     def test_replica(self):
         callback = mock.Mock()
-        with DBRecorder('replica', callback):
-            run_query('replica', 'SELECT 1')
-        callback.assert_called_once_with(DBOp('replica', 'SELECT #'))
+        with DBRecorder("replica", callback):
+            run_query("replica", "SELECT 1")
+        callback.assert_called_once_with(DBOp("replica", "SELECT #"))
 
     def test_secondary_default_not_recorded(self):
         callback = mock.Mock()
-        with DBRecorder('second', callback):
-            run_query('default', 'SELECT 1')
+        with DBRecorder("second", callback):
+            run_query("default", "SELECT 1")
         assert len(callback.mock_calls) == 0
 
 
 class AllDBRecorderTests(TestCase):
-    databases = ('default', 'second', 'replica')
+    databases = ("default", "second", "replica")
 
     def test_records_all(self):
         callback = mock.Mock()
         with AllDBRecorder(callback):
-            run_query('replica', 'SELECT 1')
-            run_query('default', 'SELECT 2')
-            run_query('second', 'SELECT 3')
+            run_query("replica", "SELECT 1")
+            run_query("default", "SELECT 2")
+            run_query("second", "SELECT 3")
 
         assert callback.mock_calls == [
-            mock.call(DBOp('replica', 'SELECT #')),
-            mock.call(DBOp('default', 'SELECT #')),
-            mock.call(DBOp('second', 'SELECT #')),
+            mock.call(DBOp("replica", "SELECT #")),
+            mock.call(DBOp("default", "SELECT #")),
+            mock.call(DBOp("second", "SELECT #")),
         ]

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -4,7 +4,6 @@ from django_perf_rec.orm import patch_ORM_to_be_deterministic
 
 
 class PatchORMToBeDeterministicTests(SimpleTestCase):
-
     def test_call_it(self):
         patch_ORM_to_be_deterministic()
 

--- a/tests/test_pytest_duplicate.py
+++ b/tests/test_pytest_duplicate.py
@@ -9,4 +9,4 @@ pytestmark = [pytest.mark.django_db]
 
 def test_duplicate_name():
     with record():
-        run_query('default', 'SELECT 1337')
+        run_query("default", "SELECT 1337")

--- a/tests/test_pytest_duplicate_other.py
+++ b/tests/test_pytest_duplicate_other.py
@@ -8,9 +8,9 @@ from .utils import run_query
 pytestmark = [pytest.mark.django_db]
 
 
-@override_settings(PERF_REC={'MODE': 'none'})
+@override_settings(PERF_REC={"MODE": "none"})
 def test_duplicate_name():
     with record():
-        run_query('default', 'SELECT 1337')
-        run_query('default', 'SELECT 4997')
-        run_query('default', 'SELECT 4998')
+        run_query("default", "SELECT 1337")
+        run_query("default", "SELECT 4997")
+        run_query("default", "SELECT 4998")

--- a/tests/test_pytest_fixture_usage.py
+++ b/tests/test_pytest_fixture_usage.py
@@ -14,7 +14,7 @@ def record_auto_name():
 
 
 def test_auto_name(record_auto_name):
-    run_query('default', 'SELECT 1337')
+    run_query("default", "SELECT 1337")
 
 
 @pytest.fixture
@@ -24,7 +24,7 @@ def record_auto_name_with_request(request):
 
 
 def test_auto_name_with_request(record_auto_name_with_request):
-    run_query('default', 'SELECT 1337')
+    run_query("default", "SELECT 1337")
 
 
 @pytest.fixture
@@ -39,4 +39,4 @@ def record_build_name(request):
 
 
 def test_build_name(record_build_name):
-    run_query('default', 'SELECT 1337')
+    run_query("default", "SELECT 1337")

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -6,7 +6,6 @@ from .utils import pretend_not_under_pytest
 
 
 class PytestPluginTests(SimpleTestCase):
-
     def test_in_pytest(self):
         # We always run our tests in pytest
         assert pytest_plugin.in_pytest

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -2,217 +2,230 @@ from django_perf_rec.sql import sql_fingerprint
 
 
 def test_empty():
-    assert sql_fingerprint('') == ''
-    assert sql_fingerprint("\n\n    \n") == ''
+    assert sql_fingerprint("") == ""
+    assert sql_fingerprint("\n\n    \n") == ""
 
 
 def test_select():
-    assert (
-        sql_fingerprint("SELECT `f1`, `f2` FROM `b`") ==
-        "SELECT ... FROM `b`"
-    )
+    assert sql_fingerprint("SELECT `f1`, `f2` FROM `b`") == "SELECT ... FROM `b`"
 
 
 def test_select_show_columns(settings):
     assert (
-        sql_fingerprint("SELECT `f1`, `f2` FROM `b`", hide_columns=False) ==
-        "SELECT `f1`, `f2` FROM `b`"
+        sql_fingerprint("SELECT `f1`, `f2` FROM `b`", hide_columns=False)
+        == "SELECT `f1`, `f2` FROM `b`"
     )
 
 
 def test_select_limit(settings):
     assert (
-        sql_fingerprint("SELECT `f1`, `f2` FROM `b` LIMIT 12", hide_columns=False) ==
-        "SELECT `f1`, `f2` FROM `b` LIMIT #"
+        sql_fingerprint("SELECT `f1`, `f2` FROM `b` LIMIT 12", hide_columns=False)
+        == "SELECT `f1`, `f2` FROM `b` LIMIT #"
     )
 
 
 def test_select_coalesce_show_columns(settings):
     assert (
         sql_fingerprint(
-            "SELECT `table`.`f1`, COALESCE(table.f2->>'a', table.f2->>'b', 'default') FROM `table`",
-            hide_columns=False) ==
-        "SELECT `table`.`f1`, COALESCE(table.f2->>#, table.f2->>#, #) FROM `table`"
+            (
+                "SELECT `table`.`f1`, COALESCE(table.f2->>'a', table.f2->>'b', "
+                + "'default') FROM `table`"
+            ),
+            hide_columns=False,
+        )
+        == "SELECT `table`.`f1`, COALESCE(table.f2->>#, table.f2->>#, #) FROM `table`"
     )
 
 
 def test_select_where():
     assert (
-        sql_fingerprint("SELECT DISTINCT `table`.`field` FROM `table` WHERE `table`.`id` = 1") ==
-        "SELECT DISTINCT `table`.`field` FROM `table` WHERE `table`.`id` = #"
+        sql_fingerprint(
+            "SELECT DISTINCT `table`.`field` FROM `table` WHERE `table`.`id` = 1"
+        )
+        == "SELECT DISTINCT `table`.`field` FROM `table` WHERE `table`.`id` = #"
     )
 
 
 def test_select_where_show_columns(settings):
     assert (
-        sql_fingerprint("SELECT DISTINCT `table`.`field` FROM `table` WHERE `table`.`id` = 1", hide_columns=False) ==
-        "SELECT DISTINCT `table`.`field` FROM `table` WHERE `table`.`id` = #"
+        sql_fingerprint(
+            "SELECT DISTINCT `table`.`field` FROM `table` WHERE `table`.`id` = 1",
+            hide_columns=False,
+        )
+        == "SELECT DISTINCT `table`.`field` FROM `table` WHERE `table`.`id` = #"
     )
 
 
 def test_select_comment():
     assert (
-        sql_fingerprint("SELECT /* comment */ `f1`, `f2` FROM `b`") ==
-        "SELECT /* comment */ ... FROM `b`"
+        sql_fingerprint("SELECT /* comment */ `f1`, `f2` FROM `b`")
+        == "SELECT /* comment */ ... FROM `b`"
     )
 
 
 def test_select_comment_show_columns(settings):
     assert (
-        sql_fingerprint("SELECT /* comment */ `f1`, `f2` FROM `b`", hide_columns=False) ==
-        "SELECT /* comment */ `f1`, `f2` FROM `b`"
+        sql_fingerprint("SELECT /* comment */ `f1`, `f2` FROM `b`", hide_columns=False)
+        == "SELECT /* comment */ `f1`, `f2` FROM `b`"
     )
 
 
 def test_select_join():
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = 1') ==
-        'SELECT ... FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = #'
+        sql_fingerprint(
+            "SELECT f1, f2 FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = 1"
+        )
+        == "SELECT ... FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = #"
     )
 
 
 def test_select_join_show_columns(settings):
     assert (
         sql_fingerprint(
-            'SELECT f1, f2 FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = 1',
-            hide_columns=False) ==
-        'SELECT f1, f2 FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = #'
+            "SELECT f1, f2 FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = 1",
+            hide_columns=False,
+        )
+        == "SELECT f1, f2 FROM a INNER JOIN b ON (a.b_id = b.id) WHERE a.f2 = #"
     )
 
 
 def test_select_order_by():
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a ORDER BY f3') ==
-        'SELECT ... FROM a ORDER BY f3'
+        sql_fingerprint("SELECT f1, f2 FROM a ORDER BY f3")
+        == "SELECT ... FROM a ORDER BY f3"
     )
 
 
 def test_select_order_by_limit():
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a ORDER BY f3 LIMIT 12') ==
-        'SELECT ... FROM a ORDER BY f3 LIMIT #'
+        sql_fingerprint("SELECT f1, f2 FROM a ORDER BY f3 LIMIT 12")
+        == "SELECT ... FROM a ORDER BY f3 LIMIT #"
     )
 
 
 def test_select_order_by_show_columns(settings):
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a ORDER BY f3', hide_columns=False) ==
-        'SELECT f1, f2 FROM a ORDER BY f3'
+        sql_fingerprint("SELECT f1, f2 FROM a ORDER BY f3", hide_columns=False)
+        == "SELECT f1, f2 FROM a ORDER BY f3"
     )
 
 
 def test_select_order_by_multiple():
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a ORDER BY f3, f4') ==
-        'SELECT ... FROM a ORDER BY f3, f4'
+        sql_fingerprint("SELECT f1, f2 FROM a ORDER BY f3, f4")
+        == "SELECT ... FROM a ORDER BY f3, f4"
     )
 
 
 def test_select_group_by():
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1') ==
-        'SELECT ... FROM a GROUP BY f1'
+        sql_fingerprint("SELECT f1, f2 FROM a GROUP BY f1")
+        == "SELECT ... FROM a GROUP BY f1"
     )
 
 
 def test_select_group_by_show_columns(settings):
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1', hide_columns=False) ==
-        'SELECT f1, f2 FROM a GROUP BY f1'
+        sql_fingerprint("SELECT f1, f2 FROM a GROUP BY f1", hide_columns=False)
+        == "SELECT f1, f2 FROM a GROUP BY f1"
     )
 
 
 def test_select_group_by_multiple():
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1, f2') ==
-        'SELECT ... FROM a GROUP BY f1, f2'
+        sql_fingerprint("SELECT f1, f2 FROM a GROUP BY f1, f2")
+        == "SELECT ... FROM a GROUP BY f1, f2"
     )
 
 
 def test_select_group_by_having():
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > 21') ==
-        'SELECT ... FROM a GROUP BY f1 HAVING f1 > #'
+        sql_fingerprint("SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > 21")
+        == "SELECT ... FROM a GROUP BY f1 HAVING f1 > #"
     )
 
 
 def test_select_group_by_having_show_columns(settings):
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > 21', hide_columns=False) ==
-        'SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > #'
+        sql_fingerprint(
+            "SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > 21", hide_columns=False
+        )
+        == "SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > #"
     )
 
 
 def test_select_group_by_having_multiple():
     assert (
-        sql_fingerprint('SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > 21, f2 < 42') ==
-        'SELECT ... FROM a GROUP BY f1 HAVING f1 > #, f2 < #'
+        sql_fingerprint("SELECT f1, f2 FROM a GROUP BY f1 HAVING f1 > 21, f2 < 42")
+        == "SELECT ... FROM a GROUP BY f1 HAVING f1 > #, f2 < #"
     )
 
 
 def test_insert():
     assert (
-        sql_fingerprint("INSERT INTO `table` (`f1`, `f2`) VALUES ('v1', 2)") ==
-        "INSERT INTO `table` (...) VALUES (...)"
+        sql_fingerprint("INSERT INTO `table` (`f1`, `f2`) VALUES ('v1', 2)")
+        == "INSERT INTO `table` (...) VALUES (...)"
     )
 
 
 def test_insert_show_columns(settings):
     assert (
-        sql_fingerprint("INSERT INTO `table` (`f1`, `f2`) VALUES ('v1', 2)", hide_columns=False) ==
-        "INSERT INTO `table` (`f1`, `f2`) VALUES (#, #)"
+        sql_fingerprint(
+            "INSERT INTO `table` (`f1`, `f2`) VALUES ('v1', 2)", hide_columns=False
+        )
+        == "INSERT INTO `table` (`f1`, `f2`) VALUES (#, #)"
     )
 
 
 def test_update():
     assert (
-        sql_fingerprint("UPDATE `table` SET `foo` = 'bar' WHERE `table`.`id` = 1") ==
-        "UPDATE `table` SET ... WHERE `table`.`id` = #"
+        sql_fingerprint("UPDATE `table` SET `foo` = 'bar' WHERE `table`.`id` = 1")
+        == "UPDATE `table` SET ... WHERE `table`.`id` = #"
     )
 
 
 def test_declare_cursor():
     assert (
-        sql_fingerprint('DECLARE "_django_curs_140239496394496_1300" NO SCROLL CURSOR WITHOUT') ==
-        'DECLARE "_django_curs_#" NO SCROLL CURSOR WITHOUT'
+        sql_fingerprint(
+            'DECLARE "_django_curs_140239496394496_1300" NO SCROLL CURSOR WITHOUT'
+        )
+        == 'DECLARE "_django_curs_#" NO SCROLL CURSOR WITHOUT'
     )
 
 
 def test_savepoint():
-    assert (
-        sql_fingerprint("SAVEPOINT `s140323809662784_x54`") ==
-        "SAVEPOINT `#`"
-    )
+    assert sql_fingerprint("SAVEPOINT `s140323809662784_x54`") == "SAVEPOINT `#`"
 
 
 def test_rollback_to_savepoint():
     assert (
-        sql_fingerprint("ROLLBACK TO SAVEPOINT `s140323809662784_x54`") ==
-        "ROLLBACK TO SAVEPOINT `#`"
+        sql_fingerprint("ROLLBACK TO SAVEPOINT `s140323809662784_x54`")
+        == "ROLLBACK TO SAVEPOINT `#`"
     )
 
 
 def test_release_savepoint():
     assert (
-        sql_fingerprint("RELEASE SAVEPOINT `s140699855320896_x17`") ==
-        "RELEASE SAVEPOINT `#`"
+        sql_fingerprint("RELEASE SAVEPOINT `s140699855320896_x17`")
+        == "RELEASE SAVEPOINT `#`"
     )
 
 
 def test_null_value():
     assert (
         sql_fingerprint(
-            "SELECT `f1`, `f2` FROM `b` WHERE `b`.`name` IS NULL",
-            hide_columns=False) ==
-        "SELECT `f1`, `f2` FROM `b` WHERE `b`.`name` IS #"
+            "SELECT `f1`, `f2` FROM `b` WHERE `b`.`name` IS NULL", hide_columns=False
+        )
+        == "SELECT `f1`, `f2` FROM `b` WHERE `b`.`name` IS #"
     )
 
 
 def test_strip_duplicate_whitespaces():
     assert (
         sql_fingerprint(
-            "SELECT    `f1`,  `f2` FROM  `b` WHERE   `b`.`f1` IS  NULL LIMIT 12  ") ==
-        "SELECT ... FROM `b` WHERE `b`.`f1` IS # LIMIT #"
+            "SELECT    `f1`,  `f2` FROM  `b` WHERE   `b`.`f1` IS  NULL LIMIT 12  "
+        )
+        == "SELECT ... FROM `b` WHERE `b`.`f1` IS # LIMIT #"
     )
 
 
@@ -221,22 +234,24 @@ def test_strip_duplicate_whitespaces_recursive():
         sql_fingerprint(
             "SELECT    `f1`,  `f2`, (   COALESCE(b.f3->>'en',   b.f3->>'fr', '')) "
             "FROM  `b` WHERE   (`b`.`f1` IS   NULL OR (  EXISTS COUNT(1) )) LIMIT 12  ",
-            hide_columns=False) ==
-        "SELECT `f1`, `f2`, (COALESCE(b.f3->>#, b.f3->>#, #)) "
+            hide_columns=False,
+        )
+        == "SELECT `f1`, `f2`, (COALESCE(b.f3->>#, b.f3->>#, #)) "
         "FROM `b` WHERE (`b`.`f1` IS # OR (EXISTS COUNT(#))) LIMIT #"
     )
 
 
 def test_strip_newlines():
     assert (
-        sql_fingerprint("SELECT `f1`, `f2`\nFROM `b`\n LIMIT 12\n\n") ==
-        "SELECT ... FROM `b` LIMIT #"
+        sql_fingerprint("SELECT `f1`, `f2`\nFROM `b`\n LIMIT 12\n\n")
+        == "SELECT ... FROM `b` LIMIT #"
     )
 
 
 def test_strip_raw_query():
     assert (
-        sql_fingerprint("""
+        sql_fingerprint(
+            """
 SELECT 'f1'
     , 'f2'
     , 'f3'
@@ -247,7 +262,11 @@ EXISTS (
     FROM "table_b"
     WHERE "table_b"."id" = 1
 ) = true)
-""") ==
-        'SELECT ... FROM "table_a" WHERE "table_a"."f1" = # OR ("table_a"."type" = #'
-        ' AND EXISTS (SELECT "table_b"."id" FROM "table_b" WHERE "table_b"."id" = # ) = true)'
+"""
+        )
+        == (
+            'SELECT ... FROM "table_a" WHERE "table_a"."f1" = # OR '
+            + '("table_a"."type" = # AND EXISTS (SELECT "table_b"."id" FROM '
+            + '"table_b" WHERE "table_b"."id" = # ) = true)'
+        )
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,40 +4,37 @@ from django_perf_rec.utils import current_test, sorted_names
 
 
 class CurrentTestTests(SimpleTestCase):
-
     def test_here(self):
         details = current_test()
         assert details.file_path == __file__
-        assert details.class_name == 'CurrentTestTests'
-        assert details.test_name == 'test_here'
+        assert details.class_name == "CurrentTestTests"
+        assert details.test_name == "test_here"
 
     def test_twice_same(self):
         assert current_test() == current_test()
 
     def test_functional(self):
-
         def test_thats_functional():
             return current_test()
 
         details = test_thats_functional()
         assert details.file_path == __file__
         assert details.class_name is None
-        assert details.test_name == 'test_thats_functional'
+        assert details.test_name == "test_thats_functional"
 
 
 class SortedNamesTests(SimpleTestCase):
-
     def test_empty(self):
         assert sorted_names([]) == []
 
     def test_just_default(self):
-        assert sorted_names(['default']) == ['default']
+        assert sorted_names(["default"]) == ["default"]
 
     def test_just_something(self):
-        assert sorted_names(['something']) == ['something']
+        assert sorted_names(["something"]) == ["something"]
 
     def test_does_sort(self):
-        assert sorted_names(['b', 'a']) == ['a', 'b']
+        assert sorted_names(["b", "a"]) == ["a", "b"]
 
     def test_sort_keeps_default_first(self):
-        assert sorted_names(['a', 'default']) == ['default', 'a']
+        assert sorted_names(["a", "default"]) == ["default", "a"]

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -9,7 +9,6 @@ from django_perf_rec.yaml import KVFile
 
 
 class KVFileTests(SimpleTestCase):
-
     def setUp(self):
         super(KVFileTests, self).setUp()
         KVFile._clear_load_cache()
@@ -21,71 +20,71 @@ class KVFileTests(SimpleTestCase):
 
     def test_load_no_permissions(self):
         with pytest.raises(IOError):
-            KVFile('/')
+            KVFile("/")
 
     def test_load_non_existent_is_empty(self):
-        kvf = KVFile(self.temp_dir + '/foo.yml')
+        kvf = KVFile(self.temp_dir + "/foo.yml")
         assert len(kvf) == 0
         default = object()
-        assert kvf.get('foo', default) is default
+        assert kvf.get("foo", default) is default
 
     def test_load_existent(self):
-        file_name = self.temp_dir + '/foo.yml'
-        with open(file_name, 'w') as fp:
-            fp.write('foo: bar')
+        file_name = self.temp_dir + "/foo.yml"
+        with open(file_name, "w") as fp:
+            fp.write("foo: bar")
 
         kvf = KVFile(file_name)
         assert len(kvf) == 1
-        assert kvf.get('foo', '') == 'bar'
+        assert kvf.get("foo", "") == "bar"
 
     def test_load_empty(self):
-        file_name = self.temp_dir + '/foo.yml'
-        with open(file_name, 'w') as fp:
-            fp.write('')
+        file_name = self.temp_dir + "/foo.yml"
+        with open(file_name, "w") as fp:
+            fp.write("")
 
         assert len(KVFile(file_name)) == 0
 
     def test_load_whitespace_empty(self):
-        file_name = self.temp_dir + '/foo.yml'
-        with open(file_name, 'w') as fp:
-            fp.write(' \n')
+        file_name = self.temp_dir + "/foo.yml"
+        with open(file_name, "w") as fp:
+            fp.write(" \n")
 
         assert len(KVFile(file_name)) == 0
 
     def test_load_non_dictionary(self):
-        file_name = self.temp_dir + '/foo.yml'
-        with open(file_name, 'w') as fp:
-            fp.write('[not, a, dictionary]')
+        file_name = self.temp_dir + "/foo.yml"
+        with open(file_name, "w") as fp:
+            fp.write("[not, a, dictionary]")
 
         with pytest.raises(TypeError) as excinfo:
             KVFile(file_name)
-        assert 'not a dictionary' in str(excinfo.value)
+        assert "not a dictionary" in str(excinfo.value)
 
     def test_get_after_set_same(self):
-        kvf = KVFile(self.temp_dir + '/foo.yml')
-        kvf.set_and_save('foo', 'bar')
+        kvf = KVFile(self.temp_dir + "/foo.yml")
+        kvf.set_and_save("foo", "bar")
 
         assert len(kvf) == 1
-        assert kvf.get('foo', '') == 'bar'
+        assert kvf.get("foo", "") == "bar"
 
     def test_load_second_same(self):
-        kvf = KVFile(self.temp_dir + '/foo.yml')
-        kvf.set_and_save('foo', 'bar')
-        kvf2 = KVFile(self.temp_dir + '/foo.yml')
+        kvf = KVFile(self.temp_dir + "/foo.yml")
+        kvf.set_and_save("foo", "bar")
+        kvf2 = KVFile(self.temp_dir + "/foo.yml")
 
         assert len(kvf2) == 1
-        assert kvf2.get('foo', '') == 'bar'
+        assert kvf2.get("foo", "") == "bar"
 
     def test_sets_dont_cause_append_duplication(self):
-        file_name = self.temp_dir + '/foo.yml'
+        file_name = self.temp_dir + "/foo.yml"
         kvf = KVFile(file_name)
-        kvf.set_and_save('foo', 'bar')
-        kvf.set_and_save('foo2', 'bar')
+        kvf.set_and_save("foo", "bar")
+        kvf.set_and_save("foo2", "bar")
 
-        with open(file_name, 'r') as fp:
+        with open(file_name, "r") as fp:
             lines = fp.readlines()
             fp.seek(0)
             data = yaml.safe_load(fp)
 
         assert len(lines) == 2
-        assert data == {'foo': 'bar', 'foo2': 'bar'}
+        assert data == {"foo": "bar", "foo2": "bar"}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@ def temporary_path(path):
 
 
 def ensure_path_does_not_exist(path):
-    if path.endswith('/'):
+    if path.endswith("/"):
         shutil.rmtree(path, ignore_errors=True)
     else:
         try:


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.5
* Reconfigure isort and flake8
* Drop flake8-commas and rely on Black's trailing comma insertion only
* Run black on the code
* Add README badge