### PR TITLE
Reword supported versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,9 +63,9 @@ Use **pip**:
 Requirements
 ============
 
-Python 3.5-3.8 supported.
+Python 3.5 to 3.8 supported.
 
-Django 1.11-3.0 suppported.
+Django 1.11 to 3.0 suppported.
 
 API
 ===


### PR DESCRIPTION
As per https://github.com/adamchainz/django-cors-headers/pull/468 , using a dash has confused some users.