### PR TITLE
Fix ORM Q() patch in Django 2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,7 +13,7 @@ Pending release
   ``importlib.metadata.version("django-perf-rec")``
   (`docs <https://docs.python.org/3.8/library/importlib.metadata.html#distribution-versions>`__ /
   `backport <https://pypi.org/project/importlib-metadata/>`__).
-* Fix ``Q()`` Patchy patch for Django 2.0+.
+* Fix ``Q()`` Patchy patch for Django 2.0+ with non-ANDed ``Q()``'s.
 
 4.4.0 (2019-05-09)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,7 @@ Pending release
   ``importlib.metadata.version("django-perf-rec")``
   (`docs <https://docs.python.org/3.8/library/importlib.metadata.html#distribution-versions>`__ /
   `backport <https://pypi.org/project/importlib-metadata/>`__).
+* Fix ``Q()`` Patchy patch for Django 2.0+.
 
 4.4.0 (2019-05-09)
 ------------------

--- a/src/django_perf_rec/orm.py
+++ b/src/django_perf_rec/orm.py
@@ -113,8 +113,9 @@ elif django.VERSION < (2, 0, 3):
         Q.__init__ = __init__
 
 
-# After Django 2.0.3, kwargs are sorted so we don't need to patch anything
 else:
 
+    # After Django 2.0.3, kwargs are sorted so we don't need to patch anything
+    # https://code.djangoproject.com/ticket/29125
     def patch_Q():
         pass

--- a/src/django_perf_rec/orm.py
+++ b/src/django_perf_rec/orm.py
@@ -83,11 +83,38 @@ else:
         )
 
 
-def patch_Q():
-    # This one can't be done by patchy since __init__ is different in Python 3,
-    # maybe one day https://github.com/adamchainz/patchy/issues/31 will be
-    # fixed.
-    def __init__(self, *args, **kwargs):
-        super(Q, self).__init__(children=list(args) + sorted(kwargs.items()))
+if django.VERSION < (2, 0):
 
-    Q.__init__ = __init__
+    def patch_Q():
+        # This one can't be done by patchy since __init__ is different in Python 3,
+        # maybe one day https://github.com/adamchainz/patchy/issues/31 will be
+        # fixed.
+        def __init__(self, *args, **kwargs):
+            super(Q, self).__init__(children=list(args) + sorted(kwargs.items()))
+
+        Q.__init__ = __init__
+
+
+elif django.VERSION < (2, 0, 3):
+
+    def patch_Q():
+        # This one can't be done by patchy since __init__ is different in Python 3,
+        # maybe one day https://github.com/adamchainz/patchy/issues/31 will be
+        # fixed.
+        def __init__(self, *args, **kwargs):
+            connector = kwargs.pop("_connector", None)
+            negated = kwargs.pop("_negated", False)
+            super().__init__(
+                children=list(args) + sorted(kwargs.items()),
+                connector=connector,
+                negated=negated,
+            )
+
+        Q.__init__ = __init__
+
+
+# After Django 2.0.3, kwargs are sorted so we don't need to patch anything
+else:
+
+    def patch_Q():
+        pass

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -1,3 +1,5 @@
+import django
+import pytest
 from django.db.models import Q
 from django.test import SimpleTestCase
 
@@ -11,6 +13,7 @@ class PatchORMToBeDeterministicTests(SimpleTestCase):
     def test_call_it_again(self):
         patch_ORM_to_be_deterministic()
 
+    @pytest.mark.skipif(django.VERSION < (2, 0), reason="Django 2.0+")
     def test_q_connector(self):
         q = Q(foo="bar") | Q(bar="foo")
         _, _, kwargs = q.deconstruct()

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from django.test import SimpleTestCase
 
 from django_perf_rec.orm import patch_ORM_to_be_deterministic
@@ -9,3 +10,8 @@ class PatchORMToBeDeterministicTests(SimpleTestCase):
 
     def test_call_it_again(self):
         patch_ORM_to_be_deterministic()
+
+    def test_q_connector(self):
+        q = Q(foo="bar") | Q(bar="foo")
+        _, _, kwargs = q.deconstruct()
+        self.assertEqual(kwargs, {"_connector": "OR"})

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -15,6 +15,7 @@ class PatchORMToBeDeterministicTests(SimpleTestCase):
 
     @pytest.mark.skipif(django.VERSION < (2, 0), reason="Django 2.0+")
     def test_q_connector(self):
-        q = Q(foo="bar") | Q(bar="foo")
-        _, _, kwargs = q.deconstruct()
-        self.assertEqual(kwargs, {"_connector": "OR"})
+        q1 = Q(foo="bar") | Q(bar="foo")
+        _path, args, kwargs = q1.deconstruct()
+        q2 = Q(*args, **kwargs)
+        self.assertEqual(q1, q2)


### PR DESCRIPTION
In Django 2.0, we have to handle `_connector` and `_negated` kwargs separately in `Q()`.

In Django 2.0.3, children are sorted, so we no longer need to make the patch.