### PR TITLE
Factorize some db & cache operations code

### DIFF
--- a/src/django_perf_rec/api.py
+++ b/src/django_perf_rec/api.py
@@ -100,7 +100,7 @@ class PerformanceRecorder:
             name_parts.append(db_op.alias)
         name = "|".join(name_parts)
 
-        self.record.append({name: db_op.sql})
+        self.record.append({name: db_op.operation})
 
     def on_cache_op(self, cache_op):
         name_parts = ["cache"]

--- a/src/django_perf_rec/cache.py
+++ b/src/django_perf_rec/cache.py
@@ -4,11 +4,9 @@ from collections.abc import Mapping, Sequence
 from functools import wraps
 from types import MethodType
 
-from django.conf import settings
 from django.core.cache import caches
 
-from django_perf_rec.operation import Operation
-from django_perf_rec.utils import sorted_names
+from django_perf_rec.operation import AllSourceRecorder, Operation
 
 
 class CacheOp(Operation):
@@ -116,22 +114,10 @@ class CacheRecorder:
     )
 
 
-class AllCacheRecorder:
+class AllCacheRecorder(AllSourceRecorder):
     """
     Launches CacheRecorders on all the active caches
     """
 
-    def __init__(self, callback):
-        self.callback = callback
-
-    def __enter__(self):
-        self.recorders = []
-        for name in sorted_names(settings.CACHES.keys()):
-            recorder = CacheRecorder(name, self.callback)
-            recorder.__enter__()
-            self.recorders.append(recorder)
-
-    def __exit__(self, type_, value, traceback):
-        for recorder in reversed(self.recorders):
-            recorder.__exit__(type_, value, traceback)
-        self.recorders = []
+    sources_setting = "CACHES"
+    recorder_class = CacheRecorder

--- a/src/django_perf_rec/cache.py
+++ b/src/django_perf_rec/cache.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping, Sequence
 from functools import wraps
 from types import MethodType
 
-from django.core.cache import caches
+from django.core.cache import DEFAULT_CACHE_ALIAS, caches
 
 from django_perf_rec.operation import AllSourceRecorder, Operation
 
@@ -46,6 +46,14 @@ class CacheOp(Operation):
 
     def __eq__(self, other):
         return super().__eq__(other) and self.operation == other.operation
+
+    @property
+    def name(self):
+        name_parts = ["cache"]
+        if self.alias != DEFAULT_CACHE_ALIAS:
+            name_parts.append(self.alias)
+        name_parts.append(self.operation)
+        return "|".join(name_parts)
 
 
 class CacheRecorder:

--- a/src/django_perf_rec/cache.py
+++ b/src/django_perf_rec/cache.py
@@ -7,19 +7,21 @@ from types import MethodType
 from django.conf import settings
 from django.core.cache import caches
 
+from django_perf_rec.operation import Operation
 from django_perf_rec.utils import sorted_names
 
 
-class CacheOp:
+class CacheOp(Operation):
     def __init__(self, alias, operation, key_or_keys):
-        self.alias = alias
         self.operation = operation
         if isinstance(key_or_keys, str):
-            self.key_or_keys = self.clean_key(key_or_keys)
+            cleaned_key_or_keys = self.clean_key(key_or_keys)
         elif isinstance(key_or_keys, (Mapping, Sequence)):
-            self.key_or_keys = sorted(self.clean_key(k) for k in key_or_keys)
+            cleaned_key_or_keys = sorted(self.clean_key(k) for k in key_or_keys)
         else:
             raise ValueError("key_or_keys must be a string, mapping, or sequence")
+
+        super().__init__(alias, cleaned_key_or_keys)
 
     @classmethod
     def clean_key(cls, key):
@@ -45,12 +47,7 @@ class CacheOp:
     )
 
     def __eq__(self, other):
-        return (
-            isinstance(other, CacheOp)
-            and self.alias == other.alias
-            and self.operation == other.operation
-            and self.key_or_keys == other.key_or_keys
-        )
+        return super().__eq__(other) and self.operation == other.operation
 
 
 class CacheRecorder:

--- a/src/django_perf_rec/db.py
+++ b/src/django_perf_rec/db.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from types import MethodType
 
-from django.db import connections
+from django.db import DEFAULT_DB_ALIAS, connections
 
 from django_perf_rec.operation import AllSourceRecorder, Operation
 from django_perf_rec.orm import patch_ORM_to_be_deterministic
@@ -12,6 +12,13 @@ from django_perf_rec.sql import sql_fingerprint
 class DBOp(Operation):
     def __repr__(self):
         return "DBOp({!r}, {!r})".format(repr(self.alias), repr(self.query))
+
+    @property
+    def name(self):
+        name_parts = ["db"]
+        if self.alias != DEFAULT_DB_ALIAS:
+            name_parts.append(self.alias)
+        return "|".join(name_parts)
 
 
 class DBRecorder:

--- a/src/django_perf_rec/db.py
+++ b/src/django_perf_rec/db.py
@@ -69,7 +69,7 @@ class DBRecorder:
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         connection = connections[self.alias]
-        connection.force_debug_cursor = False
+        connection.force_debug_cursor = self.orig_force_debug_cursor
         connection.ops.last_executed_query = self.orig_last_executed_query
 
 

--- a/src/django_perf_rec/db.py
+++ b/src/django_perf_rec/db.py
@@ -4,26 +4,16 @@ from types import MethodType
 from django.conf import settings
 from django.db import connections
 
+from django_perf_rec.operation import Operation
 from django_perf_rec.orm import patch_ORM_to_be_deterministic
 from django_perf_rec.settings import perf_rec_settings
 from django_perf_rec.sql import sql_fingerprint
 from django_perf_rec.utils import sorted_names
 
 
-class DBOp:
-    def __init__(self, alias, sql):
-        self.alias = alias
-        self.sql = sql
-
+class DBOp(Operation):
     def __repr__(self):
-        return "DBOp({!r}, {!r})".format(repr(self.alias), repr(self.sql))
-
-    def __eq__(self, other):
-        return (
-            isinstance(other, DBOp)
-            and self.alias == other.alias
-            and self.sql == other.sql
-        )
+        return "DBOp({!r}, {!r})".format(repr(self.alias), repr(self.query))
 
 
 class DBRecorder:
@@ -59,7 +49,8 @@ class DBRecorder:
                 hide_columns = perf_rec_settings.HIDE_COLUMNS
                 callback(
                     DBOp(
-                        alias=alias, sql=sql_fingerprint(sql, hide_columns=hide_columns)
+                        alias=alias,
+                        query=sql_fingerprint(sql, hide_columns=hide_columns),
                     )
                 )
                 return sql

--- a/src/django_perf_rec/operation.py
+++ b/src/django_perf_rec/operation.py
@@ -1,0 +1,12 @@
+
+class Operation(object):
+    def __init__(self, alias, query):
+        self.alias = alias
+        self.query = query
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, type(self))
+            and self.alias == other.alias
+            and self.query == other.query
+        )

--- a/src/django_perf_rec/operation.py
+++ b/src/django_perf_rec/operation.py
@@ -1,3 +1,7 @@
+from django.conf import settings
+
+from django_perf_rec.utils import sorted_names
+
 
 class Operation(object):
     def __init__(self, alias, query):
@@ -10,3 +14,27 @@ class Operation(object):
             and self.alias == other.alias
             and self.query == other.query
         )
+
+
+class AllSourceRecorder(object):
+    """
+    Launches Recorders on all the active sources
+    """
+
+    sources_setting = None
+    recorder_class = None
+
+    def __init__(self, callback):
+        self.callback = callback
+
+    def __enter__(self):
+        self.recorders = []
+        for name in sorted_names(getattr(settings, self.sources_setting).keys()):
+            recorder = self.recorder_class(name, self.callback)
+            recorder.__enter__()
+            self.recorders.append(recorder)
+
+    def __exit__(self, type_, value, traceback):
+        for recorder in reversed(self.recorders):
+            recorder.__exit__(type_, value, traceback)
+        self.recorders = []

--- a/src/django_perf_rec/operation.py
+++ b/src/django_perf_rec/operation.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django_perf_rec.utils import sorted_names
 
 
-class Operation(object):
+class Operation:
     def __init__(self, alias, query):
         self.alias = alias
         self.query = query
@@ -16,7 +16,7 @@ class Operation(object):
         )
 
 
-class AllSourceRecorder(object):
+class AllSourceRecorder:
     """
     Launches Recorders on all the active sources
     """

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -32,13 +32,13 @@ class CacheOpTests(SimpleTestCase):
         op = CacheOp("default", "foo", "bar")
         assert op.alias == "default"
         assert op.operation == "foo"
-        assert op.key_or_keys == "bar"
+        assert op.query == "bar"
 
     def test_keys(self):
         op = CacheOp("default", "foo", ["bar", "baz"])
         assert op.alias == "default"
         assert op.operation == "foo"
-        assert op.key_or_keys == ["bar", "baz"]
+        assert op.query == ["bar", "baz"]
 
     def test_invalid(self):
         with pytest.raises(ValueError):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -13,7 +13,7 @@ class DBOpTests(SimpleTestCase):
     def test_create(self):
         op = DBOp("myalias", "SELECT 1")
         assert op.alias == "myalias"
-        assert op.sql == "SELECT 1"
+        assert op.query == "SELECT 1"
 
     def test_equal(self):
         assert DBOp("foo", "bar") == DBOp("foo", "bar")


### PR DESCRIPTION
Hello!
I tried todo some refactoring around operations, like we talked about in https://github.com/adamchainz/django-perf-rec/issues/212 
I did not find an interesting way to refactor `CacheRecorder` and `DBRecorder`, even if they share the same logic, the code is really different. Also I'm not totally convinced by some of my name choices..

Anyway, is it what you had in mind ? 
