### PR TITLE
Create YAML files as non-executable

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 History
 =======
 
+* Create YAML files as non-executable. This will not be applied to existing
+  files, modify their permissions if necessary, or delete and recreate.
+
+  Thanks to Peter Law for the report in `Issue #264
+  <https://github.com/adamchainz/django-perf-rec/issues/264>`__.
+
 4.6.0 (2020-05-20)
 ------------------
 

--- a/src/django_perf_rec/yaml.py
+++ b/src/django_perf_rec/yaml.py
@@ -54,7 +54,7 @@ class KVFile:
         if self.data.get(key, object()) == value:
             return
 
-        fd = os.open(self.file_name, os.O_RDWR | os.O_CREAT)
+        fd = os.open(self.file_name, os.O_RDWR | os.O_CREAT, mode=0o666)
         with os.fdopen(fd, "r+") as fp:
             locks.lock(fd, locks.LOCK_EX)
 


### PR DESCRIPTION
`os.open()` defaults to `mode=0o777`, which isn't so helpful. Use `0o666`, the
default used by `open()`, on top of which the umask is applied.

Fixes #264.