### PR TITLE
Remove DBOp.__repr__

### DIFF
--- a/src/django_perf_rec/db.py
+++ b/src/django_perf_rec/db.py
@@ -10,9 +10,6 @@ from django_perf_rec.sql import sql_fingerprint
 
 
 class DBOp(Operation):
-    def __repr__(self):
-        return "DBOp({!r}, {!r})".format(repr(self.alias), repr(self.query))
-
     @property
     def name(self):
         name_parts = ["db"]


### PR DESCRIPTION
It's weird this was the only class with a __repr__ defined, I think it can go since it's only helpful for debugging the development of the library.