### PR TITLE
Support arbitrary collections of cache keys

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+* Support arbitrary collections of keys being passed to Django cache operations.
+  Previously only mappings and sequences were supported, now sets and mapping
+  views will also work.
+
+  Thanks to Peter Law in
+  `PR #378 <https://github.com/adamchainz/django-perf-rec/pull/378>`__.
+
 4.14.0 (2021-06-02)
 -------------------
 

--- a/src/django_perf_rec/cache.py
+++ b/src/django_perf_rec/cache.py
@@ -1,7 +1,7 @@
 import inspect
 import re
 import traceback
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection
 from functools import wraps
 from types import MethodType
 
@@ -16,10 +16,10 @@ class CacheOp(Operation):
         self.operation = operation
         if isinstance(key_or_keys, str):
             cleaned_key_or_keys = self.clean_key(key_or_keys)
-        elif isinstance(key_or_keys, (Mapping, Sequence)):
+        elif isinstance(key_or_keys, Collection):
             cleaned_key_or_keys = sorted(self.clean_key(k) for k in key_or_keys)
         else:
-            raise ValueError("key_or_keys must be a string, mapping, or sequence")
+            raise ValueError("key_or_keys must be a string or collection")
 
         super().__init__(alias, cleaned_key_or_keys, traceback)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -38,6 +38,18 @@ class CacheOpTests(SimpleTestCase):
         assert op.operation == "foo"
         assert op.query == ["bar", "baz"]
 
+    def test_keys_frozenset(self):
+        op = CacheOp("default", "foo", frozenset(["bar", "baz"]), None)
+        assert op.alias == "default"
+        assert op.operation == "foo"
+        assert op.query == ["bar", "baz"]
+
+    def test_keys_dict_keys(self):
+        op = CacheOp("default", "foo", {"bar": "baz"}.keys(), None)
+        assert op.alias == "default"
+        assert op.operation == "foo"
+        assert op.query == ["bar"]
+
     def test_invalid(self):
         with pytest.raises(ValueError):
             CacheOp("x", "foo", object(), None)


### PR DESCRIPTION
This ensures that passing a set of keys will work. While Django supports arbitrary iterables, I've opted not to support those here as we'd then need to handle cases where we collapse a generator.

I suspect that that could be handled (by passing the resulting values to Django), but is a bigger change than needed to fix the original issue.

Fixes https://github.com/adamchainz/django-perf-rec/issues/344