### PR TITLE
Add an 'overwrite' MODE for use in development

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+* Add new ``MODE`` option, ``'overwrite'``, which creates or updates missing
+  records silently.
+
+  Thanks to Peter Law in `PR #461 <https://github.com/adamchainz/django-perf-rec/pull/461>`__.
+
 4.18.0 (2022-01-10)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -262,7 +262,7 @@ when a performance record does not exist during a test run.
   probably want to use this mode in CI, to ensure new tests fail if their
   corresponding performance records were not committed.
 * ``'all'`` creates missing records and then raises ``AssertionError``.
-* ``'overwrite'`` creates or updates records silently
+* ``'overwrite'`` creates or updates records silently.
 
 Usage in Pytest
 ===============

--- a/README.rst
+++ b/README.rst
@@ -262,6 +262,7 @@ when a performance record does not exist during a test run.
   probably want to use this mode in CI, to ensure new tests fail if their
   corresponding performance records were not committed.
 * ``'all'`` creates missing records and then raises ``AssertionError``.
+* ``'overwrite'`` creates or updates records silently
 
 Usage in Pytest
 ===============

--- a/src/django_perf_rec/api.py
+++ b/src/django_perf_rec/api.py
@@ -109,7 +109,7 @@ class PerformanceRecorder:
                 self.record_name
             )
 
-        if orig_record is not None:
+        if orig_record is not None and perf_rec_settings.MODE != "overwrite":
             msg = f"Performance record did not match for {self.record_name}"
             if not pytest_plugin.in_pytest:
                 msg += f"\n{record_diff(orig_record, self.record)}"

--- a/src/django_perf_rec/settings.py
+++ b/src/django_perf_rec/settings.py
@@ -8,7 +8,7 @@ from django.conf import settings
 if sys.version_info >= (3, 8):
     from typing import Literal
 
-    ModeType = Literal["once", "none", "all"]
+    ModeType = Literal["all", "none", "once", "overwrite"]
 else:
     ModeType = str
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -228,6 +228,20 @@ class RecordTests(TestCase):
             full_path = os.path.join(FILE_DIR, "perf_files", "api", "test_api.perf.yml")
             assert os.path.exists(full_path)
 
+    @override_settings(PERF_REC={"MODE": "overwrite"})
+    def test_mode_overwrite(self):
+        temp_dir = os.path.join(FILE_DIR, "perf_files/")
+        with temporary_path(temp_dir):
+
+            with record(path="perf_files/api/"):
+                caches["default"].get("foo")
+
+            full_path = os.path.join(FILE_DIR, "perf_files", "api", "test_api.perf.yml")
+            assert os.path.exists(full_path)
+
+            with record(path="perf_files/api/"):
+                caches["default"].get("bar")
+
     def test_delete_on_cascade_called_twice(self):
         arthur = Author.objects.create(name="Arthur", age=42)
         with record():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -241,14 +241,21 @@ class RecordTests(TestCase):
         temp_dir = os.path.join(FILE_DIR, "perf_files/")
         with temporary_path(temp_dir):
 
-            with record(path="perf_files/api/"):
+            with record(path="perf_files/api/", record_name="test_mode_overwrite"):
                 caches["default"].get("foo")
 
             full_path = os.path.join(FILE_DIR, "perf_files", "api", "test_api.perf.yml")
             assert os.path.exists(full_path)
 
-            with record(path="perf_files/api/"):
+            with record(path="perf_files/api/", record_name="test_mode_overwrite"):
                 caches["default"].get("bar")
+
+            full_path = os.path.join(FILE_DIR, "perf_files", "api", "test_api.perf.yml")
+            with open(full_path) as f:
+                text = f.read()
+
+            assert "bar" in text
+            assert "foo" not in text
 
     def test_delete_on_cascade_called_twice(self):
         arthur = Author.objects.create(name="Arthur", age=42)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -192,11 +192,19 @@ class RecordTests(TestCase):
         temp_dir = os.path.join(FILE_DIR, "perf_files/")
         with temporary_path(temp_dir):
 
-            with record(path="perf_files/api/"):
+            with record(path="perf_files/api/", record_name="test_mode_once"):
                 caches["default"].get("foo")
 
             full_path = os.path.join(FILE_DIR, "perf_files", "api", "test_api.perf.yml")
             assert os.path.exists(full_path)
+
+            with pytest.raises(AssertionError) as excinfo:
+
+                with record(path="perf_files/api/", record_name="test_mode_once"):
+                    caches["default"].get("bar")
+
+            message = str(excinfo.value)
+            assert "Performance record did not match for test_mode_once" in message
 
     @override_settings(PERF_REC={"MODE": "none"})
     def test_mode_none(self):


### PR DESCRIPTION
This provides a way to iterate tests rapidly without worrying about the query snapshot changes, which can then be manually reviewed afterwards. This is often more convenient when making larger changes to areas of code.

Fixes https://github.com/adamchainz/django-perf-rec/issues/460