### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,6 @@ target-version = ['py37']
 [tool.django-stubs]
 django_settings_module = "tests.settings"
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 plugins = ["mypy_django_plugin.main"]

--- a/src/django_perf_rec/__init__.py
+++ b/src/django_perf_rec/__init__.py
@@ -1,6 +1,8 @@
 """
 isort:skip_file
 """
+from __future__ import annotations
+
 try:
     import pytest
 

--- a/src/django_perf_rec/api.py
+++ b/src/django_perf_rec/api.py
@@ -12,7 +12,9 @@ from django_perf_rec.db import AllDBRecorder
 from django_perf_rec.operation import Operation
 from django_perf_rec.settings import perf_rec_settings
 from django_perf_rec.types import PerformanceRecordItem
-from django_perf_rec.utils import TestDetails, current_test, record_diff
+from django_perf_rec.utils import current_test
+from django_perf_rec.utils import record_diff
+from django_perf_rec.utils import TestDetails
 from django_perf_rec.yaml import KVFile
 
 

--- a/src/django_perf_rec/cache.py
+++ b/src/django_perf_rec/cache.py
@@ -5,14 +5,21 @@ import re
 import traceback
 from collections.abc import Collection
 from functools import wraps
-from types import MethodType, TracebackType
-from typing import Any, Callable
+from types import MethodType
+from types import TracebackType
+from typing import Any
+from typing import Callable
+from typing import cast
 from typing import Collection as TypingCollection
-from typing import Pattern, TypeVar, cast
+from typing import Pattern
+from typing import TypeVar
 
-from django.core.cache import DEFAULT_CACHE_ALIAS, caches
+from django.core.cache import caches
+from django.core.cache import DEFAULT_CACHE_ALIAS
 
-from django_perf_rec.operation import AllSourceRecorder, BaseRecorder, Operation
+from django_perf_rec.operation import AllSourceRecorder
+from django_perf_rec.operation import BaseRecorder
+from django_perf_rec.operation import Operation
 
 
 class CacheOp(Operation):

--- a/src/django_perf_rec/db.py
+++ b/src/django_perf_rec/db.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 import traceback
 from functools import wraps
-from types import MethodType, TracebackType
-from typing import Any, Callable, TypeVar, cast
+from types import MethodType
+from types import TracebackType
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import TypeVar
 
-from django.db import DEFAULT_DB_ALIAS, connections
+from django.db import connections
+from django.db import DEFAULT_DB_ALIAS
 
-from django_perf_rec.operation import AllSourceRecorder, BaseRecorder, Operation
+from django_perf_rec.operation import AllSourceRecorder
+from django_perf_rec.operation import BaseRecorder
+from django_perf_rec.operation import Operation
 from django_perf_rec.settings import perf_rec_settings
 from django_perf_rec.sql import sql_fingerprint
 

--- a/src/django_perf_rec/operation.py
+++ b/src/django_perf_rec/operation.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from traceback import StackSummary
 from types import TracebackType
-from typing import Any, Callable
+from typing import Any
+from typing import Callable
 
 from django.conf import settings
 

--- a/src/django_perf_rec/sql.py
+++ b/src/django_perf_rec/sql.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Container
 
-from sqlparse import parse, tokens
-from sqlparse.sql import Comment, Comparison, IdentifierList, Parenthesis, Token
+from sqlparse import parse
+from sqlparse import tokens
+from sqlparse.sql import Comment
+from sqlparse.sql import Comparison
+from sqlparse.sql import IdentifierList
+from sqlparse.sql import Parenthesis
+from sqlparse.sql import Token
 
 
 @lru_cache(maxsize=500)

--- a/src/django_perf_rec/types.py
+++ b/src/django_perf_rec/types.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Dict, List, Union
+from typing import Dict
+from typing import List
+from typing import Union
 
 PerformanceRecordItem = Dict[str, Union[str, List[str]]]
 PerformanceRecord = List[PerformanceRecordItem]

--- a/src/django_perf_rec/utils.py
+++ b/src/django_perf_rec/utils.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import difflib
 import inspect
 from types import FrameType
-from typing import Any, Iterable
+from typing import Any
+from typing import Iterable
 
 from django_perf_rec import _HAVE_PYTEST
 from django_perf_rec.types import PerformanceRecord

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,13 +5,21 @@ import os
 import pytest
 import yaml
 from django.core.cache import caches
-from django.db.models import F, Q
+from django.db.models import F
+from django.db.models import Q
 from django.db.models.functions import Upper
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import override_settings
+from django.test import SimpleTestCase
+from django.test import TestCase
 
-from django_perf_rec import TestCaseMixin, get_perf_path, get_record_name, record
+from django_perf_rec import get_perf_path
+from django_perf_rec import get_record_name
+from django_perf_rec import record
+from django_perf_rec import TestCaseMixin
 from tests.testapp.models import Author
-from tests.utils import pretend_not_under_pytest, run_query, temporary_path
+from tests.utils import pretend_not_under_pytest
+from tests.utils import run_query
+from tests.utils import temporary_path
 
 FILE_DIR = os.path.dirname(__file__)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,9 +5,12 @@ from unittest import mock
 
 import pytest
 from django.core.cache import caches
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase
+from django.test import TestCase
 
-from django_perf_rec.cache import AllCacheRecorder, CacheOp, CacheRecorder
+from django_perf_rec.cache import AllCacheRecorder
+from django_perf_rec.cache import CacheOp
+from django_perf_rec.cache import CacheRecorder
 from tests.utils import override_extract_stack
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-from traceback import StackSummary, extract_stack
+from traceback import extract_stack
+from traceback import StackSummary
 from unittest import mock
 
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase
+from django.test import TestCase
 
-from django_perf_rec.db import AllDBRecorder, DBOp, DBRecorder
-from tests.utils import override_extract_stack, run_query
+from django_perf_rec.db import AllDBRecorder
+from django_perf_rec.db import DBOp
+from django_perf_rec.db import DBRecorder
+from tests.utils import override_extract_stack
+from tests.utils import run_query
 
 
 class DBOpTests(SimpleTestCase):

--- a/tests/test_pytest_fixture_usage.py
+++ b/tests/test_pytest_fixture_usage.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import pytest
 
-from django_perf_rec import get_perf_path, get_record_name, record
+from django_perf_rec import get_perf_path
+from django_perf_rec import get_record_name
+from django_perf_rec import record
 from tests.utils import run_query
 
 pytestmark = [pytest.mark.django_db(databases=("default", "second", "replica"))]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from django.test import SimpleTestCase
 
-from django_perf_rec.utils import TestDetails, current_test, sorted_names
+from django_perf_rec.utils import current_test
+from django_perf_rec.utils import sorted_names
+from django_perf_rec.utils import TestDetails
 
 
 class CurrentTestTests(SimpleTestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,11 @@ import shutil
 import traceback
 from contextlib import contextmanager
 from functools import wraps
-from typing import Any, Callable, Generator, TypeVar, cast
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Generator
+from typing import TypeVar
 from unittest import mock
 
 from django.db import connections


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
