### PR TITLE
Fetch test name from pytest

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Fetch the test name from pytest where possible, which pulls in its parametrized name.
+
+  Thanks to Gert Van Gool in `PR #537 <https://github.com/adamchainz/django-perf-rec/pull/537>`__.
+
 4.22.2 (2023-05-30)
 -------------------
 

--- a/src/django_perf_rec/utils.py
+++ b/src/django_perf_rec/utils.py
@@ -38,9 +38,9 @@ def current_test() -> TestDetails:
     assert frame is not None
     try:
         while True:
-            details = _get_details_from_test_function(
+            details = _get_details_from_pytest_request(
                 frame
-            ) or _get_details_from_pytest_request(frame)
+            ) or _get_details_from_test_function(frame)
 
             if details is not None:
                 return details
@@ -91,7 +91,7 @@ def _get_details_from_pytest_request(frame: FrameType) -> TestDetails | None:
     return TestDetails(
         file_path=request.fspath.strpath,
         class_name=class_name,
-        test_name=request.function.__name__,
+        test_name=request.node.name,
     )
 
 

--- a/tests/test_pytest_parametrize.perf.yml
+++ b/tests/test_pytest_parametrize.perf.yml
@@ -1,0 +1,6 @@
+test_with_parametrize[1337]:
+- db: 'SELECT #'
+test_with_parametrize[42]:
+- db: 'SELECT #'
+test_with_parametrize[73]:
+- db: 'SELECT #'

--- a/tests/test_pytest_parametrize.py
+++ b/tests/test_pytest_parametrize.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import random
+
 import pytest
 
 from django_perf_rec import record
@@ -7,8 +9,11 @@ from tests.utils import run_query
 
 pytestmark = [pytest.mark.django_db(databases=("default", "second"))]
 
+VALUES = [42, 73, 1337]
+random.shuffle(VALUES)
 
-@pytest.mark.parametrize("query_param", [42, 73, 1337])
+
+@pytest.mark.parametrize("query_param", VALUES)
 def test_with_parametrize(request, query_param):
     with record():
         run_query("default", f"SELECT {query_param}")

--- a/tests/test_pytest_parametrize.py
+++ b/tests/test_pytest_parametrize.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import pytest
+
+from django_perf_rec import record
+from tests.utils import run_query
+
+pytestmark = [pytest.mark.django_db(databases=("default", "second"))]
+
+
+@pytest.mark.parametrize("query_param", [42, 73, 1337])
+def test_with_parametrize(request, query_param):
+    with record():
+        run_query("default", f"SELECT {query_param}")


### PR DESCRIPTION
When using the pytest `parametrize` marker and a random test order, there will be test failures if the queries/caching changes between those parameters.

Instead of having `test_name` and `test_name.2`, it would become `test_name[{value}]`.

Relates to #346