### PR TITLE
Avoid crashing on cache calls with keyword args

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Avoid crashing when recording cache function calls that pass ``key`` as a keyword argument, like ``cache.set(key="abc", value="def")``.
+
+  Thanks to Benoît Casoetto in `PR #545 <https://github.com/adamchainz/django-perf-rec/pull/545>`__.
+
 4.22.1 (2023-04-23)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* Avoid crashing when recording cache function calls that pass ``key`` as a keyword argument, like ``cache.set(key="abc", value="def")``.
+* Avoid crashing when recording cache function calls that pass ``key`` or ``keys`` as a keyword argument, like ``cache.set(key="abc", value="def")``.
 
   Thanks to Benoît Casoetto in `PR #545 <https://github.com/adamchainz/django-perf-rec/pull/545>`__.
 

--- a/src/django_perf_rec/cache.py
+++ b/src/django_perf_rec/cache.py
@@ -109,7 +109,10 @@ class CacheRecorder(BaseRecorder):
                     del frame
 
                 if not is_internal_call:
-                    key_or_keys = args[0] if args else kwargs["key"]
+                    if "key" in kwargs:
+                        key_or_keys = kwargs["key"]
+                    else:
+                        key_or_keys = args[0]
                     callback(
                         CacheOp(
                             alias=alias,

--- a/src/django_perf_rec/cache.py
+++ b/src/django_perf_rec/cache.py
@@ -109,7 +109,7 @@ class CacheRecorder(BaseRecorder):
                     del frame
 
                 if not is_internal_call:
-                    key_or_keys = args[0]
+                    key_or_keys = args[0] if args else kwargs["key"]
                     callback(
                         CacheOp(
                             alias=alias,

--- a/src/django_perf_rec/cache.py
+++ b/src/django_perf_rec/cache.py
@@ -109,10 +109,12 @@ class CacheRecorder(BaseRecorder):
                     del frame
 
                 if not is_internal_call:
-                    if "key" in kwargs:
+                    if args:
+                        key_or_keys = args[0]
+                    elif "key" in kwargs:
                         key_or_keys = kwargs["key"]
                     else:
-                        key_or_keys = args[0]
+                        key_or_keys = kwargs["keys"]
                     callback(
                         CacheOp(
                             alias=alias,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -132,13 +132,15 @@ class AllCacheRecorderTests(TestCase):
         callback = mock.Mock()
         with AllCacheRecorder(callback):
             caches["default"].get("foo")
+            caches["default"].get(key="foo")
+            caches["default"].get_many(keys=["foo"])
             caches["second"].set("bar", "baz")
-            caches["second"].set(key="bar_with_named_param", value="baz")
             caches["default"].delete_many(["foo"])
 
         assert callback.mock_calls == [
             mock.call(CacheOp("default", "get", "foo", stack_summary)),
+            mock.call(CacheOp("default", "get", "foo", stack_summary)),
+            mock.call(CacheOp("default", "get_many", ["foo"], stack_summary)),
             mock.call(CacheOp("second", "set", "bar", stack_summary)),
-            mock.call(CacheOp("second", "set", "bar_with_named_param", stack_summary)),
             mock.call(CacheOp("default", "delete_many", ["foo"], stack_summary)),
         ]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -133,10 +133,12 @@ class AllCacheRecorderTests(TestCase):
         with AllCacheRecorder(callback):
             caches["default"].get("foo")
             caches["second"].set("bar", "baz")
+            caches["second"].set(key="bar_with_named_param", value="baz")
             caches["default"].delete_many(["foo"])
 
         assert callback.mock_calls == [
             mock.call(CacheOp("default", "get", "foo", stack_summary)),
             mock.call(CacheOp("second", "set", "bar", stack_summary)),
+            mock.call(CacheOp("second", "set", "bar_with_named_param", stack_summary)),
             mock.call(CacheOp("default", "delete_many", ["foo"], stack_summary)),
         ]


### PR DESCRIPTION
Makes the library compatible with using `cache.set(key=...)`

Fixes #536.