### PR TITLE
Update Django support claim in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Requirements
 
 Python 3.7 to 3.11 supported.
 
-Django 2.2 to 4.2 supported.
+Django 3.2 to 4.2 supported.
 
 ----
 


### PR DESCRIPTION
`README.md` claims that Django >=2.2 is supported. However the package `install_requires` `django>=3.2`, and older Django versions are not in the tox matrix.