### PR TITLE
Optimize sql_fingerprint() a bit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Optimize ``sql_fingerprint()`` a bit, yielding ~2% savings.
+
 4.25.0 (2023-10-11)
 -------------------
 


### PR DESCRIPTION
Grabbed a bunch of queries and timed in IPython with:

```
In [1]: from django_perf_rec.sql import sql_fingerprint ; from example import queries

In [2]: %%timeit
   ...: sql_fingerprint.cache_clear()
   ...: for query in queries:
   ...:     sql_fingerprint(query)
   ...:
   ...:     sql_fingerprint(query, hide_columns=False)
   ...:
47.7 ms ± 92.8 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Applied some easy, obvious optimizations from reading the code, and the same took 46.9ms instead, again with tight variance. That’s ~1ms faster, or ~2%.