### PR TITLE
Fix test naming with request local

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Unreleased
 
   Thanks to q0w in `PR #669 <https://github.com/adamchainz/django-perf-rec/pull/669>`__.
 
+* Fix test name detection when a test function contains a variable called ``request``.
+
+  Thanks to Konstantin Alekseev for the initial patch in `PR #659 <https://github.com/adamchainz/django-perf-rec/pull/659>`__.
+
 4.28.0 (2025-02-06)
 -------------------
 

--- a/src/django_perf_rec/utils.py
+++ b/src/django_perf_rec/utils.py
@@ -80,7 +80,7 @@ def _get_details_from_pytest_request(frame: FrameType) -> TestDetails | None:
         return None
 
     request = frame.f_locals.get("request", None)
-    if request is None:
+    if request is None or not hasattr(request, "cls"):
         return None
 
     if request.cls is not None:

--- a/src/django_perf_rec/utils.py
+++ b/src/django_perf_rec/utils.py
@@ -80,11 +80,17 @@ def _get_details_from_pytest_request(frame: FrameType) -> TestDetails | None:
         return None
 
     request = frame.f_locals.get("request", None)
-    if request is None or not hasattr(request, "cls"):
+    if request is None:
         return None
 
-    if request.cls is not None:
-        class_name = request.cls.__name__
+    try:
+        cls = request.cls
+    except AttributeError:
+        # Doesn't look like a pytest request object
+        return None
+
+    if cls is not None:
+        class_name = cls.__name__
     else:
         class_name = None
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,6 +24,16 @@ class CurrentTestTests(SimpleTestCase):
         assert details.class_name is None
         assert details.test_name == "test_thats_functional"
 
+    def test_request_local(self):
+        def test_with_request() -> TestDetails:
+            request = object()  # noqa: F841
+            return current_test()
+
+        details = test_with_request()
+        assert details.file_path == __file__
+        assert details.class_name is None
+        assert details.test_name == "test_with_request"
+
 
 class SortedNamesTests(SimpleTestCase):
     def test_empty(self):


### PR DESCRIPTION
repro:

```
def test_perf():
    request = object()
    with record():
         pass
```