### PR TITLE
Fingerprint multiple queries from one SQL string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,9 +3,11 @@ Changelog
 =========
 
 Unreleased
--------------------
+----------
 
 * Support fingerprinting SQL strings containing multiple queries.
+
+  Thanks to q0w in `PR #669 <https://github.com/adamchainz/django-perf-rec/pull/669>`__.
 
 4.28.0 (2025-02-06)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Unreleased
+-------------------
+
+* Support fingerprinting SQL strings containing multiple queries.
+
 4.28.0 (2025-02-06)
 -------------------
 

--- a/src/django_perf_rec/sql.py
+++ b/src/django_perf_rec/sql.py
@@ -19,9 +19,14 @@ def sql_fingerprint(query: str, hide_columns: bool = True) -> str:
     if not parsed_queries:
         return ""
 
-    parsed_query = sql_recursively_strip(parsed_queries[0])
-    sql_recursively_simplify(parsed_query, hide_columns=hide_columns)
-    return str(parsed_query).strip()
+    fingerprinted_queries = []
+    for parsed_query in parsed_queries:
+        stripped_query = sql_recursively_strip(parsed_query)
+        sql_recursively_simplify(stripped_query, hide_columns=hide_columns)
+
+        fingerprinted_queries.append(stripped_query)
+
+    return "".join([str(q) for q in fingerprinted_queries]).strip()
 
 
 sql_deletable_tokens = frozenset(

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -323,3 +323,12 @@ def test_in_subquery():
         sql_fingerprint("SELECT `f1`, `f2` FROM `b` WHERE `x` IN (SELECT 1)")
         == "SELECT ... FROM `b` WHERE `x` IN (SELECT #)"
     )
+
+
+def test_multiple_queries():
+    assert (
+        sql_fingerprint(
+            "SELECT set_config('flag1', true), set_config('flag2', true); UPDATE user SET username = 'username'"
+        )
+        == "SELECT ...; UPDATE user SET ..."
+    )


### PR DESCRIPTION
If sql query contains multiple queries, it captures only first one